### PR TITLE
Integrate Parakeet V3/EOU as alternative ASR engine via FluidAudio

### DIFF
--- a/wispr.xcodeproj/project.pbxproj
+++ b/wispr.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		000C012F2F50C874003B4CDA /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 000C012E2F50C874003B4CDA /* WhisperKit */; };
+		00FA01002F58A00000000001 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 00FA01012F58A00000000001 /* FluidAudio */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,6 +59,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				000C012F2F50C874003B4CDA /* WhisperKit in Frameworks */,
+				00FA01002F58A00000000001 /* FluidAudio in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -120,6 +122,7 @@
 			name = wispr;
 			packageProductDependencies = (
 				000C012E2F50C874003B4CDA /* WhisperKit */,
+				00FA01012F58A00000000001 /* FluidAudio */,
 			);
 			productName = wispr;
 			productReference = 00A1C0B62F50AD06001D1A22 /* wispr.app */;
@@ -205,6 +208,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				000C012D2F50C874003B4CDA /* XCRemoteSwiftPackageReference "WhisperKit" */,
+				00FA01022F58A00000000001 /* XCRemoteSwiftPackageReference "FluidAudio" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 00A1C0B72F50AD06001D1A22 /* Products */;
@@ -646,6 +650,14 @@
 				minimumVersion = 0.15.0;
 			};
 		};
+		00FA01022F58A00000000001 /* XCRemoteSwiftPackageReference "FluidAudio" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/FluidInference/FluidAudio.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.12.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -653,6 +665,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 000C012D2F50C874003B4CDA /* XCRemoteSwiftPackageReference "WhisperKit" */;
 			productName = WhisperKit;
+		};
+		00FA01012F58A00000000001 /* FluidAudio */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 00FA01022F58A00000000001 /* XCRemoteSwiftPackageReference "FluidAudio" */;
+			productName = FluidAudio;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/wispr.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wispr.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "be2b508cf91e00ccfdfd83e8177b94c9aee963c0dbf9b604f03fa19a3d85c0d4",
+  "originHash" : "6448c4cff3a6be06bb8cfeab56abda72744a0395416a857478ac54fad7f8f558",
   "pins" : [
+    {
+      "identity" : "fluidaudio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/FluidInference/FluidAudio.git",
+      "state" : {
+        "revision" : "1cf23303df75df13e8dc92a0343c40006fbbe234",
+        "version" : "0.12.1"
+      }
+    },
     {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",

--- a/wispr/Services/CompositeTranscriptionEngine.swift
+++ b/wispr/Services/CompositeTranscriptionEngine.swift
@@ -1,0 +1,181 @@
+//
+//  CompositeTranscriptionEngine.swift
+//  wispr
+//
+//  Aggregates multiple TranscriptionEngine instances behind a single
+//  TranscriptionEngine interface, routing calls to the engine that
+//  owns a given model.
+//
+
+import Foundation
+
+actor CompositeTranscriptionEngine: TranscriptionEngine {
+
+    private let engines: [any TranscriptionEngine]
+
+    /// Index of the engine whose model is currently active.
+    /// We track this ourselves so cross-engine switches are clean.
+    private var activeEngineIndex: Int?
+
+    init(engines: [any TranscriptionEngine]) {
+        self.engines = engines
+    }
+
+    // MARK: - Engine Lookup
+
+    private func engineIndex(for modelId: String) async -> Int? {
+        for (i, engine) in engines.enumerated() {
+            let models = await engine.availableModels()
+            if models.contains(where: { $0.id == modelId }) {
+                return i
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Model Management
+
+    func availableModels() async -> [ModelInfo] {
+        var all: [ModelInfo] = []
+        for engine in engines {
+            let models = await engine.availableModels()
+            all.append(contentsOf: models)
+        }
+        return all
+    }
+
+    func downloadModel(_ model: ModelInfo) async -> AsyncThrowingStream<DownloadProgress, Error> {
+        guard let idx = await engineIndex(for: model.id) else {
+            let (stream, continuation) = AsyncThrowingStream.makeStream(of: DownloadProgress.self)
+            continuation.finish(throwing: WisprError.modelDownloadFailed("No engine found for model \(model.id)"))
+            return stream
+        }
+        let innerStream = await engines[idx].downloadModel(model)
+
+        // Wrap so activeEngineIndex updates only after successful completion.
+        let (outer, continuation) = AsyncThrowingStream.makeStream(of: DownloadProgress.self)
+        let engine = self
+        Task {
+            do {
+                for try await progress in innerStream {
+                    continuation.yield(progress)
+                }
+                await engine.setActiveEngine(idx)
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+        return outer
+    }
+
+    private func setActiveEngine(_ idx: Int) async {
+        if let currentIdx = activeEngineIndex, currentIdx != idx {
+            await engines[currentIdx].unloadCurrentModel()
+        }
+        activeEngineIndex = idx
+    }
+
+    func deleteModel(_ modelName: String) async throws {
+        guard let idx = await engineIndex(for: modelName) else {
+            throw WisprError.modelDeletionFailed("No engine found for model \(modelName)")
+        }
+        try await engines[idx].deleteModel(modelName)
+        if activeEngineIndex == idx {
+            if await engines[idx].activeModel() == nil {
+                activeEngineIndex = nil
+            }
+        }
+    }
+
+    func loadModel(_ modelName: String) async throws {
+        guard let idx = await engineIndex(for: modelName) else {
+            throw WisprError.modelLoadFailed("No engine found for model \(modelName)")
+        }
+
+        // Unload the previous engine to free memory before loading the new one.
+        if let currentIdx = activeEngineIndex, currentIdx != idx {
+            await engines[currentIdx].unloadCurrentModel()
+        }
+
+        try await engines[idx].loadModel(modelName)
+        activeEngineIndex = idx
+    }
+
+    func switchModel(to modelName: String) async throws {
+        guard let idx = await engineIndex(for: modelName) else {
+            throw WisprError.modelLoadFailed("No engine found for model \(modelName)")
+        }
+
+        if let currentIdx = activeEngineIndex {
+            if currentIdx == idx {
+                // Same engine — delegate directly
+                try await engines[idx].switchModel(to: modelName)
+                activeEngineIndex = idx
+                return
+            }
+            // Different engine: unload the old backend to free memory.
+            await engines[currentIdx].unloadCurrentModel()
+        }
+
+        try await engines[idx].switchModel(to: modelName)
+        activeEngineIndex = idx
+    }
+
+    func validateModelIntegrity(_ modelName: String) async throws -> Bool {
+        guard let idx = await engineIndex(for: modelName) else {
+            return false
+        }
+        return try await engines[idx].validateModelIntegrity(modelName)
+    }
+
+    func modelStatus(_ modelName: String) async -> ModelStatus {
+        guard let idx = await engineIndex(for: modelName) else {
+            return .notDownloaded
+        }
+        return await engines[idx].modelStatus(modelName)
+    }
+
+    func activeModel() async -> String? {
+        guard let idx = activeEngineIndex else { return nil }
+        return await engines[idx].activeModel()
+    }
+
+    func unloadCurrentModel() async {
+        if let idx = activeEngineIndex {
+            await engines[idx].unloadCurrentModel()
+            activeEngineIndex = nil
+        }
+    }
+
+    func reloadModelWithRetry(maxAttempts: Int = 3) async throws {
+        guard let idx = activeEngineIndex else {
+            throw WisprError.modelLoadFailed("No active model to reload")
+        }
+        try await engines[idx].reloadModelWithRetry(maxAttempts: maxAttempts)
+    }
+
+    // MARK: - Transcription
+
+    func transcribe(
+        _ audioSamples: [Float],
+        language: TranscriptionLanguage
+    ) async throws -> TranscriptionResult {
+        guard let idx = activeEngineIndex else {
+            throw WisprError.modelNotDownloaded
+        }
+        return try await engines[idx].transcribe(audioSamples, language: language)
+    }
+
+    func transcribeStream(
+        _ audioStream: AsyncStream<[Float]>,
+        language: TranscriptionLanguage
+    ) async -> AsyncThrowingStream<TranscriptionResult, Error> {
+        guard let idx = activeEngineIndex else {
+            let (stream, continuation) = AsyncThrowingStream.makeStream(of: TranscriptionResult.self)
+            continuation.finish(throwing: WisprError.modelNotDownloaded)
+            return stream
+        }
+        return await engines[idx].transcribeStream(audioStream, language: language)
+    }
+}

--- a/wispr/Services/ParakeetService.swift
+++ b/wispr/Services/ParakeetService.swift
@@ -1,0 +1,488 @@
+//
+//  ParakeetService.swift
+//  wispr
+//
+//  Actor encapsulating FluidAudio Parakeet model lifecycle and transcription.
+//  Supports both Parakeet V3 (batch) and Parakeet EOU 120M (streaming).
+//  Conforms to TranscriptionEngine so it can be used interchangeably with WhisperService.
+//
+
+import AVFoundation
+import CoreML
+import Foundation
+import FluidAudio
+import os
+
+actor ParakeetService {
+    // MARK: - V3 State
+    nonisolated static let downloadedKey = "parakeetV3Downloaded"
+    nonisolated(unsafe) private var asrManager: AsrManager?
+
+    // MARK: - EOU State
+    nonisolated(unsafe) private var eouManager: StreamingEouAsrManager?
+
+    // MARK: - Shared State
+    private var activeModelName: String?
+    private var downloadTasks: [String: Bool] = [:]
+
+    // MARK: - V3 Constants
+    private static let modelId = "parakeet-v3"
+    private static let estimatedSize: Int64 = 400 * 1024 * 1024
+    private static let expectedFileCount = 23
+
+    // MARK: - EOU Constants
+    private static let eouModelId = "parakeet-eou-160ms"
+    private static let eouEstimatedSize: Int64 = 150 * 1024 * 1024
+    private static let eouExpectedFileCount = 21
+    private static let eouDownloadedKey = "parakeetEouDownloaded"
+
+    // MARK: - UserDefaults Flags
+    private var isDownloaded: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.downloadedKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.downloadedKey) }
+    }
+
+    private var isEouDownloaded: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.eouDownloadedKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.eouDownloadedKey) }
+    }
+
+    // MARK: - Internal helpers
+
+    private static func countFiles(in directory: URL) -> Int {
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { return 0 }
+        var count = 0
+        while enumerator.nextObject() != nil { count += 1 }
+        return count
+    }
+
+    // MARK: - V3 Helpers
+
+    private func downloadAndLoad() async throws {
+        let models = try await AsrModels.downloadAndLoad(version: .v3)
+        let manager = AsrManager(config: .default)
+        try await manager.initialize(models: models)
+        self.asrManager = manager
+        self.isDownloaded = true
+        Log.whisperService.debug("ParakeetService — V3 downloadAndLoad completed")
+    }
+
+    private func unload() {
+        asrManager?.cleanup()
+        asrManager = nil
+        if activeModelName == Self.modelId { activeModelName = nil }
+        Log.whisperService.debug("ParakeetService — V3 model unloaded")
+    }
+
+    // MARK: - EOU Helpers
+
+    private func eouCacheDirectory() -> URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+            .appendingPathComponent("parakeet-eou-streaming", isDirectory: true)
+            .appendingPathComponent("160ms", isDirectory: true)
+    }
+
+    private func eouModelsParentDirectory() -> URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+    }
+
+    private func downloadAndLoadEou() async throws {
+        let cacheDir = eouCacheDirectory()
+        let cachedFileCount = Self.countFiles(in: cacheDir)
+
+        // Only download if the cache is incomplete
+        if cachedFileCount < Self.eouExpectedFileCount {
+            let parentDir = eouModelsParentDirectory()
+            try await DownloadUtils.downloadRepo(.parakeetEou160, to: parentDir)
+        }
+        let config = MLModelConfiguration()
+        config.computeUnits = .cpuAndNeuralEngine
+        let manager = StreamingEouAsrManager(
+            configuration: config,
+            chunkSize: .ms160,
+            eouDebounceMs: 1280
+        )
+        try await manager.loadModels(modelDir: cacheDir)
+        self.eouManager = manager
+        self.isEouDownloaded = true
+        Log.whisperService.debug("ParakeetService — EOU downloadAndLoad completed")
+    }
+
+    private func unloadEou() {
+        eouManager = nil
+        if activeModelName == Self.eouModelId { activeModelName = nil }
+        Log.whisperService.debug("ParakeetService — EOU model unloaded")
+    }
+
+    // MARK: - Audio Helpers
+
+    private nonisolated static func createPCMBuffer(from samples: [Float], sampleRate: Double) -> AVAudioPCMBuffer {
+        let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: 1)!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count))!
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        samples.withUnsafeBufferPointer { ptr in
+            buffer.floatChannelData![0].update(from: ptr.baseAddress!, count: samples.count)
+        }
+        return buffer
+    }
+
+    // MARK: - EOU Transcription
+
+    private func transcribeWithEou(_ audioSamples: [Float]) async throws -> TranscriptionResult {
+        guard let manager = eouManager else { throw WisprError.modelNotDownloaded }
+        guard audioSamples.count >= 8000 else { throw WisprError.emptyTranscription }
+
+        await manager.reset()
+        let startTime = Date()
+        let buffer = Self.createPCMBuffer(from: audioSamples, sampleRate: 16000)
+        _ = try await manager.process(audioBuffer: buffer)
+        let text = try await manager.finish()
+
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw WisprError.emptyTranscription }
+
+        let duration = Date().timeIntervalSince(startTime)
+        Log.whisperService.debug("ParakeetService — EOU transcribed \(audioSamples.count) samples in \(duration, format: .fixed(precision: 2))s")
+
+        return TranscriptionResult(text: trimmed, detectedLanguage: nil, duration: duration)
+    }
+
+    private func transcribeStreamWithEou(_ audioStream: AsyncStream<[Float]>) -> AsyncThrowingStream<TranscriptionResult, Error> {
+        let (stream, continuation) = AsyncThrowingStream.makeStream(of: TranscriptionResult.self)
+
+        let manager = self.eouManager
+
+        let task = Task {
+            guard let manager else {
+                continuation.finish(throwing: WisprError.modelNotDownloaded)
+                return
+            }
+            await manager.reset()
+            let startTime = Date()
+            do {
+                for await chunk in audioStream {
+                    try Task.checkCancellation()
+                    let buffer = Self.createPCMBuffer(from: chunk, sampleRate: 16000)
+                    _ = try await manager.process(audioBuffer: buffer)
+                }
+                let finalText = try await manager.finish()
+                let trimmed = finalText.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    continuation.yield(TranscriptionResult(text: trimmed, detectedLanguage: nil, duration: Date().timeIntervalSince(startTime)))
+                }
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+
+        continuation.onTermination = { _ in task.cancel() }
+        return stream
+    }
+}
+
+// MARK: - TranscriptionEngine Conformance
+
+extension ParakeetService: TranscriptionEngine {
+
+    func availableModels() async -> [ModelInfo] {
+        [
+            ModelInfo(
+                id: Self.modelId,
+                displayName: "Parakeet V3",
+                sizeDescription: "~400 MB",
+                qualityDescription: "Fast, high accuracy, multilingual (25 languages)",
+                status: .notDownloaded
+            ),
+            ModelInfo(
+                id: Self.eouModelId,
+                displayName: "Parakeet Realtime (120M)",
+                sizeDescription: "~150 MB",
+                qualityDescription: "Low-latency streaming with end-of-utterance detection (English only)",
+                status: .notDownloaded
+            )
+        ]
+    }
+
+    func downloadModel(_ model: ModelInfo) async -> AsyncThrowingStream<DownloadProgress, Error> {
+        let (stream, continuation) = AsyncThrowingStream.makeStream(of: DownloadProgress.self)
+
+        guard downloadTasks[model.id] == nil else {
+            continuation.finish(throwing: WisprError.modelDownloadFailed("Model \(model.displayName) is already being downloaded"))
+            return stream
+        }
+
+        downloadTasks[model.id] = true
+
+        let isEou = model.id == Self.eouModelId
+        let estimatedSize = isEou ? Self.eouEstimatedSize : Self.estimatedSize
+        let expectedFileCount = isEou ? Self.eouExpectedFileCount : Self.expectedFileCount
+        let cacheDir = isEou ? eouCacheDirectory() : AsrModels.defaultCacheDirectory(for: .v3)
+
+        Task {
+            defer { self.downloadTasks.removeValue(forKey: model.id) }
+
+            do {
+                continuation.yield(DownloadProgress(
+                    phase: .downloading,
+                    fractionCompleted: 0.0,
+                    bytesDownloaded: 0,
+                    totalBytes: estimatedSize
+                ))
+
+                // Poll cache directory for file-count progress during download
+                let progressTask = Task {
+                    while !Task.isCancelled {
+                        try await Task.sleep(for: .milliseconds(500))
+                        let count = Self.countFiles(in: cacheDir)
+                        if count >= expectedFileCount {
+                            continuation.yield(DownloadProgress(
+                                phase: .loadingModel,
+                                fractionCompleted: 1.0,
+                                bytesDownloaded: estimatedSize,
+                                totalBytes: estimatedSize
+                            ))
+                            break
+                        }
+                        let fraction = Double(count) / Double(expectedFileCount)
+                        let downloaded = Int64(Double(estimatedSize) * fraction)
+                        continuation.yield(DownloadProgress(
+                            phase: .downloading,
+                            fractionCompleted: fraction,
+                            bytesDownloaded: downloaded,
+                            totalBytes: estimatedSize
+                        ))
+                    }
+                }
+                defer { progressTask.cancel() }
+
+                if isEou {
+                    try await self.downloadAndLoadEou()
+                } else {
+                    try await self.downloadAndLoad()
+                }
+                self.activeModelName = model.id
+
+                continuation.yield(DownloadProgress(
+                    phase: .warmingUp,
+                    fractionCompleted: 1.0,
+                    bytesDownloaded: estimatedSize,
+                    totalBytes: estimatedSize
+                ))
+                continuation.finish()
+            } catch is CancellationError {
+                continuation.finish(throwing: WisprError.modelDownloadFailed("Download of \(model.displayName) was cancelled"))
+            } catch {
+                continuation.finish(throwing: WisprError.modelDownloadFailed("Failed to download \(model.displayName): \(error.localizedDescription)"))
+            }
+        }
+
+        return stream
+    }
+
+    func deleteModel(_ modelName: String) async throws {
+        if modelName == Self.eouModelId {
+            unloadEou()
+            let cacheDir = eouCacheDirectory()
+            if FileManager.default.fileExists(atPath: cacheDir.path) {
+                do {
+                    try FileManager.default.removeItem(at: cacheDir)
+                    Log.whisperService.debug("ParakeetService — removed EOU cache at \(cacheDir.path)")
+                } catch {
+                    Log.whisperService.error("ParakeetService — failed to remove EOU cache: \(error.localizedDescription)")
+                    throw WisprError.modelDeletionFailed("Failed to delete Parakeet EOU cache: \(error.localizedDescription)")
+                }
+            }
+            isEouDownloaded = false
+        } else {
+            unload()
+            let cacheDir = AsrModels.defaultCacheDirectory(for: .v3)
+            if FileManager.default.fileExists(atPath: cacheDir.path) {
+                do {
+                    try FileManager.default.removeItem(at: cacheDir)
+                    Log.whisperService.debug("ParakeetService — removed V3 cache at \(cacheDir.path)")
+                } catch {
+                    Log.whisperService.error("ParakeetService — failed to remove V3 cache: \(error.localizedDescription)")
+                    throw WisprError.modelDeletionFailed("Failed to delete Parakeet V3 cache: \(error.localizedDescription)")
+                }
+            }
+            isDownloaded = false
+        }
+        Log.whisperService.debug("ParakeetService — model \(modelName) deleted")
+    }
+
+    func loadModel(_ modelName: String) async throws {
+        Log.whisperService.debug("ParakeetService — loadModel starting for \(modelName)")
+        do {
+            if modelName == Self.eouModelId {
+                try await downloadAndLoadEou()
+            } else {
+                try await downloadAndLoad()
+            }
+            activeModelName = modelName
+        } catch {
+            let displayName = modelName == Self.eouModelId ? "Parakeet EOU" : "Parakeet V3"
+            throw WisprError.modelLoadFailed("Failed to load \(displayName): \(error.localizedDescription)")
+        }
+    }
+
+    func switchModel(to modelName: String) async throws {
+        if modelName == Self.eouModelId {
+            unload()
+        } else {
+            unloadEou()
+        }
+        try await loadModel(modelName)
+    }
+
+    func unloadCurrentModel() async {
+        unload()
+        unloadEou()
+    }
+
+    func validateModelIntegrity(_ modelName: String) async throws -> Bool {
+        if modelName == Self.eouModelId {
+            return eouManager != nil || isEouDownloaded
+        }
+        return asrManager != nil || isDownloaded
+    }
+
+    func modelStatus(_ modelName: String) async -> ModelStatus {
+        if downloadTasks[modelName] != nil {
+            return .downloading(progress: 0.0)
+        }
+        if modelName == Self.eouModelId {
+            if modelName == activeModelName, eouManager != nil {
+                return .active
+            }
+            if isEouDownloaded {
+                return .downloaded
+            }
+        } else {
+            if modelName == activeModelName, asrManager != nil {
+                return .active
+            }
+            if isDownloaded {
+                return .downloaded
+            }
+        }
+        return .notDownloaded
+    }
+
+    func activeModel() async -> String? {
+        activeModelName
+    }
+
+    func reloadModelWithRetry(maxAttempts: Int = 3) async throws {
+        guard let currentModel = activeModelName else {
+            throw WisprError.modelLoadFailed("No active model to reload")
+        }
+
+        var lastError: Error?
+        let isEou = currentModel == Self.eouModelId
+
+        for attempt in 0..<maxAttempts {
+            do {
+                if isEou {
+                    unloadEou()
+                    try await downloadAndLoadEou()
+                } else {
+                    unload()
+                    try await downloadAndLoad()
+                }
+                activeModelName = currentModel
+                return
+            } catch {
+                lastError = error
+                try await Task.sleep(for: .seconds(pow(2.0, Double(attempt))))
+            }
+        }
+
+        if isEou { unloadEou() } else { unload() }
+        let displayName = isEou ? "Parakeet EOU" : "Parakeet V3"
+        let description = lastError?.localizedDescription ?? "Unknown error"
+        throw WisprError.modelLoadFailed(
+            "Failed to reload \(displayName) after \(maxAttempts) attempts: \(description)"
+        )
+    }
+
+    func transcribe(
+        _ audioSamples: [Float],
+        language: TranscriptionLanguage
+    ) async throws -> TranscriptionResult {
+        if activeModelName == Self.eouModelId {
+            return try await transcribeWithEou(audioSamples)
+        }
+
+        guard let asrManager else {
+            throw WisprError.modelNotDownloaded
+        }
+
+        guard audioSamples.count >= 8000 else {
+            Log.whisperService.debug("ParakeetService — audio too short (\(audioSamples.count) samples), skipping")
+            throw WisprError.emptyTranscription
+        }
+
+        let startTime = Date()
+        let result = try await asrManager.transcribe(audioSamples, source: .microphone)
+
+        let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            throw WisprError.emptyTranscription
+        }
+
+        let duration = Date().timeIntervalSince(startTime)
+        Log.whisperService.debug("ParakeetService — V3 transcribed \(audioSamples.count) samples in \(duration, format: .fixed(precision: 2))s")
+
+        return TranscriptionResult(
+            text: text,
+            detectedLanguage: nil,
+            duration: duration
+        )
+    }
+
+    func transcribeStream(
+        _ audioStream: AsyncStream<[Float]>,
+        language: TranscriptionLanguage
+    ) async -> AsyncThrowingStream<TranscriptionResult, Error> {
+        if activeModelName == Self.eouModelId {
+            return transcribeStreamWithEou(audioStream)
+        }
+
+        let (stream, continuation) = AsyncThrowingStream.makeStream(of: TranscriptionResult.self)
+
+        let task = Task {
+            do {
+                var allSamples: [Float] = []
+                for await chunk in audioStream {
+                    try Task.checkCancellation()
+                    allSamples.append(contentsOf: chunk)
+                }
+
+                try Task.checkCancellation()
+
+                let result = try await self.transcribe(allSamples, language: language)
+                continuation.yield(result)
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+
+        continuation.onTermination = { _ in
+            task.cancel()
+        }
+
+        return stream
+    }
+}

--- a/wispr/Services/TranscriptionEngine.swift
+++ b/wispr/Services/TranscriptionEngine.swift
@@ -17,10 +17,10 @@ protocol TranscriptionEngine: Actor {
     // MARK: - Model Management
 
     /// Returns the list of models this engine supports.
-    func availableModels() -> [ModelInfo]
+    func availableModels() async -> [ModelInfo]
 
     /// Downloads a model with progress reporting.
-    func downloadModel(_ model: ModelInfo) -> AsyncThrowingStream<DownloadProgress, Error>
+    func downloadModel(_ model: ModelInfo) async -> AsyncThrowingStream<DownloadProgress, Error>
 
     /// Deletes a downloaded model from disk.
     func deleteModel(_ modelName: String) async throws
@@ -31,14 +31,17 @@ protocol TranscriptionEngine: Actor {
     /// Unloads the current model and loads a different one.
     func switchModel(to modelName: String) async throws
 
+    /// Unloads the currently loaded model from memory without deleting its files.
+    func unloadCurrentModel() async
+
     /// Checks whether a downloaded model's files are intact.
     func validateModelIntegrity(_ modelName: String) async throws -> Bool
 
     /// Returns the current status of a model (not downloaded, downloading, downloaded, active).
-    func modelStatus(_ modelName: String) -> ModelStatus
+    func modelStatus(_ modelName: String) async -> ModelStatus
 
     /// Returns the name of the currently loaded model, or nil if none is loaded.
-    func activeModel() -> String?
+    func activeModel() async -> String?
 
     /// Attempts to reload the active model with exponential backoff retry.
     func reloadModelWithRetry(maxAttempts: Int) async throws
@@ -61,7 +64,7 @@ protocol TranscriptionEngine: Actor {
     func transcribeStream(
         _ audioStream: AsyncStream<[Float]>,
         language: TranscriptionLanguage
-    ) -> AsyncThrowingStream<TranscriptionResult, Error>
+    ) async -> AsyncThrowingStream<TranscriptionResult, Error>
 }
 
 // MARK: - Default Parameter Convenience

--- a/wispr/Services/WhisperService.swift
+++ b/wispr/Services/WhisperService.swift
@@ -74,7 +74,7 @@ actor WhisperService {
     /// Requirement 7.1: Return hardcoded list of standard Whisper models.
     ///
     /// - Returns: Array of ModelInfo with model details
-    func availableModels() -> [ModelInfo] {
+    func availableModels() async -> [ModelInfo] {
         return [
             ModelInfo(
                 id: "tiny",
@@ -124,7 +124,7 @@ actor WhisperService {
     ///
     /// - Parameter model: The model to download
     /// - Returns: An AsyncThrowingStream of DownloadProgress updates
-    func downloadModel(_ model: ModelInfo) -> AsyncThrowingStream<DownloadProgress, Error> {
+    func downloadModel(_ model: ModelInfo) async -> AsyncThrowingStream<DownloadProgress, Error> {
         let (stream, continuation) = AsyncThrowingStream.makeStream(of: DownloadProgress.self)
         
         // Requirement 7.4: Handle concurrent download tasks
@@ -247,11 +247,11 @@ actor WhisperService {
     func deleteModel(_ modelName: String) async throws {
         // Requirement 7.9: If deleting the active model, switch to another model first
         if modelName == activeModelName {
-            let availableModels = self.availableModels()
-            
+            let availableModels = await self.availableModels()
+
             var downloadedModels: [ModelInfo] = []
             for model in availableModels where model.id != modelName {
-                let status = modelStatus(model.id)
+                let status = await modelStatus(model.id)
                 // Use pattern matching to avoid Swift 6 concurrency warning
                 if case .downloaded = status {
                     downloadedModels.append(model)
@@ -342,7 +342,12 @@ actor WhisperService {
         activeModelName = nil
         try await loadModel(modelName)
     }
-    
+
+    func unloadCurrentModel() async {
+        whisperKit = nil
+        activeModelName = nil
+    }
+
     /// Validates the integrity of a downloaded model by checking that its
     /// directory exists and contains at least one file.
     ///
@@ -567,7 +572,7 @@ actor WhisperService {
     /// Returns the status of a specific model.
     ///
     /// Requirement 7.7: Query model status (not downloaded, downloading, downloaded, active).
-    func modelStatus(_ modelName: String) -> ModelStatus {
+    func modelStatus(_ modelName: String) async -> ModelStatus {
         if downloadTasks[modelName] != nil {
             Log.whisperService.debug("modelStatus('\(modelName)') → .downloading")
             return .downloading(progress: 0.0)
@@ -607,7 +612,7 @@ actor WhisperService {
     /// Returns the name of the currently active model.
     ///
     /// Requirement 7.7: Query which model is currently active.
-    func activeModel() -> String? {
+    func activeModel() async -> String? {
         return activeModelName
     }
 }
@@ -626,7 +631,7 @@ extension WhisperService: TranscriptionEngine {
     func transcribeStream(
         _ audioStream: AsyncStream<[Float]>,
         language: TranscriptionLanguage
-    ) -> AsyncThrowingStream<TranscriptionResult, Error> {
+    ) async -> AsyncThrowingStream<TranscriptionResult, Error> {
         let (stream, continuation) = AsyncThrowingStream.makeStream(of: TranscriptionResult.self)
 
         let task = Task {

--- a/wispr/wisprApp.swift
+++ b/wispr/wisprApp.swift
@@ -67,7 +67,11 @@ final class WisprAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate 
     let audioEngine = AudioEngine()
 
     /// On-device transcription service (actor).
-    let whisperService: any TranscriptionEngine = WhisperService()
+    /// Composite engine aggregating WhisperKit and Parakeet V3 behind a single interface.
+    let whisperService: any TranscriptionEngine = CompositeTranscriptionEngine(engines: [
+        WhisperService(),
+        ParakeetService()
+    ])
 
     /// Text insertion via Accessibility API / clipboard fallback.
     let textInsertionService = TextInsertionService()

--- a/wisprTests/CompositeTranscriptionEngineTests.swift
+++ b/wisprTests/CompositeTranscriptionEngineTests.swift
@@ -1,0 +1,413 @@
+//
+//  CompositeTranscriptionEngineTests.swift
+//  wisprTests
+//
+//  Unit tests for CompositeTranscriptionEngine bug fixes.
+//
+
+import Testing
+import Foundation
+@testable import wispr
+
+// MARK: - Mock Engine
+
+/// A fully controllable mock TranscriptionEngine for testing CompositeTranscriptionEngine.
+actor MockTranscriptionEngine: TranscriptionEngine {
+    let models: [ModelInfo]
+    private var _activeModel: String?
+    private var downloadBehavior: DownloadBehavior = .succeedImmediately
+
+    enum DownloadBehavior {
+        case succeedImmediately
+        case failWith(Error)
+        /// Yields progress via the continuation, then waits for `finishDownload()` to be called.
+        case controlled
+    }
+
+    private var downloadContinuation: AsyncThrowingStream<DownloadProgress, Error>.Continuation?
+    private var downloadFinished = false
+
+    init(models: [ModelInfo], activeModel: String? = nil) {
+        self.models = models
+        self._activeModel = activeModel
+    }
+
+    func setDownloadBehavior(_ behavior: DownloadBehavior) {
+        self.downloadBehavior = behavior
+    }
+
+    /// Call to complete a `.controlled` download successfully.
+    func finishDownload() {
+        downloadContinuation?.finish()
+        downloadContinuation = nil
+        downloadFinished = true
+    }
+
+    /// Call to fail a `.controlled` download.
+    func failDownload(_ error: Error) {
+        downloadContinuation?.finish(throwing: error)
+        downloadContinuation = nil
+        downloadFinished = true
+    }
+
+    func availableModels() async -> [ModelInfo] {
+        models
+    }
+
+    func downloadModel(_ model: ModelInfo) async -> AsyncThrowingStream<DownloadProgress, Error> {
+        let modelId = await model.id
+        let (stream, continuation) = AsyncThrowingStream.makeStream(of: DownloadProgress.self)
+
+        switch downloadBehavior {
+        case .succeedImmediately:
+            _activeModel = modelId
+            continuation.yield(DownloadProgress(phase: .downloading, fractionCompleted: 0.0, bytesDownloaded: 0, totalBytes: 100))
+            continuation.yield(DownloadProgress(phase: .warmingUp, fractionCompleted: 1.0, bytesDownloaded: 100, totalBytes: 100))
+            continuation.finish()
+
+        case .failWith(let error):
+            continuation.yield(DownloadProgress(phase: .downloading, fractionCompleted: 0.0, bytesDownloaded: 0, totalBytes: 100))
+            continuation.finish(throwing: error)
+
+        case .controlled:
+            downloadFinished = false
+            downloadContinuation = continuation
+            continuation.yield(DownloadProgress(phase: .downloading, fractionCompleted: 0.0, bytesDownloaded: 0, totalBytes: 100))
+        }
+
+        return stream
+    }
+
+    func deleteModel(_ modelName: String) async throws {
+        if _activeModel == modelName {
+            _activeModel = nil
+        }
+    }
+
+    func loadModel(_ modelName: String) async throws {
+        _activeModel = modelName
+    }
+
+    func switchModel(to modelName: String) async throws {
+        _activeModel = modelName
+    }
+
+    func validateModelIntegrity(_ modelName: String) async throws -> Bool {
+        true
+    }
+
+    func modelStatus(_ modelName: String) async -> ModelStatus {
+        if _activeModel == modelName { return .active }
+        return .downloaded
+    }
+
+    func activeModel() async -> String? {
+        _activeModel
+    }
+
+    func unloadCurrentModel() async {
+        _activeModel = nil
+    }
+
+    func reloadModelWithRetry(maxAttempts: Int) async throws {
+        // no-op
+    }
+
+    func transcribe(_ audioSamples: [Float], language: TranscriptionLanguage) async throws -> TranscriptionResult {
+        guard _activeModel != nil else { throw WisprError.modelNotDownloaded }
+        return TranscriptionResult(text: "mock", detectedLanguage: nil, duration: 0.1)
+    }
+
+    func transcribeStream(_ audioStream: AsyncStream<[Float]>, language: TranscriptionLanguage) async -> AsyncThrowingStream<TranscriptionResult, Error> {
+        let (stream, continuation) = AsyncThrowingStream.makeStream(of: TranscriptionResult.self)
+        guard _activeModel != nil else {
+            continuation.finish(throwing: WisprError.modelNotDownloaded)
+            return stream
+        }
+        continuation.yield(TranscriptionResult(text: "mock", detectedLanguage: nil, duration: 0.1))
+        continuation.finish()
+        return stream
+    }
+}
+
+// MARK: - Helper
+
+private func makeModel(_ id: String) -> ModelInfo {
+    ModelInfo(id: id, displayName: id, sizeDescription: "~100 MB", qualityDescription: "test", status: .notDownloaded)
+}
+
+// MARK: - Tests
+
+@Suite("CompositeTranscriptionEngine Tests", .serialized)
+struct CompositeTranscriptionEngineTests {
+
+    // MARK: - Bug 1: activeEngineIndex deferred until download succeeds
+
+    @Test("Download does not switch active engine while download is in progress")
+    func downloadDefersActiveEngineSwitch() async throws {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a")], activeModel: "model-a")
+        let engineB = MockTranscriptionEngine(models: [makeModel("model-b")])
+        await engineB.setDownloadBehavior(.controlled)
+
+        let composite = CompositeTranscriptionEngine(engines: [engineA, engineB])
+
+        // Manually set engine A as active by loading its model
+        try await composite.loadModel("model-a")
+        let activeBefore = await composite.activeModel()
+        #expect(activeBefore == "model-a")
+
+        // Start downloading model-b (controlled — won't finish yet)
+        let stream = await composite.downloadModel(makeModel("model-b"))
+
+        // Consume the initial progress event that was yielded synchronously
+        var iterator = stream.makeAsyncIterator()
+        let firstProgress = try await iterator.next()
+        #expect(firstProgress != nil)
+
+        // While download is in-progress, active model should still be model-a
+        let activeDuring = await composite.activeModel()
+        #expect(activeDuring == "model-a")
+
+        // Transcription should still work with engine A during download
+        let result = try await composite.transcribe([Float](repeating: 0, count: 100), language: .autoDetect)
+        #expect(result.text == "mock")
+
+        // Clean up the controlled download
+        await engineB.finishDownload()
+        while let _ = try await iterator.next() { }
+    }
+
+    @Test("Download failure does not switch active engine")
+    func downloadFailureKeepsCurrentEngine() async throws {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a")], activeModel: "model-a")
+        let engineB = MockTranscriptionEngine(models: [makeModel("model-b")])
+        await engineB.setDownloadBehavior(.failWith(WisprError.modelDownloadFailed("network error")))
+
+        let composite = CompositeTranscriptionEngine(engines: [engineA, engineB])
+        try await composite.loadModel("model-a")
+
+        let stream = await composite.downloadModel(makeModel("model-b"))
+
+        // Consume the stream (it will throw)
+        do {
+            for try await _ in stream { }
+            Issue.record("Expected download stream to throw")
+        } catch {
+            // Expected
+        }
+
+        // Active model should still be model-a
+        let active = await composite.activeModel()
+        #expect(active == "model-a")
+    }
+
+    // MARK: - Delete behavior
+
+    @Test("Deleting active model does not cross-engine fallback to stale backend")
+    func deleteActiveDoesNotReactivateStaleBackend() async throws {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a")], activeModel: "model-a")
+        let engineB = MockTranscriptionEngine(models: [makeModel("model-b")], activeModel: "model-b")
+
+        let composite = CompositeTranscriptionEngine(engines: [engineA, engineB])
+
+        // Set engine A as active — engine B still reports model-b as active internally
+        try await composite.loadModel("model-a")
+
+        // Delete model-a — should NOT reactivate engine B's stale model
+        try await composite.deleteModel("model-a")
+
+        let activeAfter = await composite.activeModel()
+        #expect(activeAfter == nil)
+    }
+
+    @Test("Deleting active model results in nil active model")
+    func deleteActiveModelResultsInNil() async throws {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a")], activeModel: "model-a")
+        let engineB = MockTranscriptionEngine(models: [makeModel("model-b")])
+
+        let composite = CompositeTranscriptionEngine(engines: [engineA, engineB])
+        try await composite.loadModel("model-a")
+
+        try await composite.deleteModel("model-a")
+
+        let activeAfter = await composite.activeModel()
+        #expect(activeAfter == nil)
+    }
+
+    @Test("Deleting non-active model does not change active engine")
+    func deleteNonActiveModelKeepsActiveEngine() async throws {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a")], activeModel: "model-a")
+        let engineB = MockTranscriptionEngine(models: [makeModel("model-b")], activeModel: "model-b")
+
+        let composite = CompositeTranscriptionEngine(engines: [engineA, engineB])
+        try await composite.loadModel("model-a")
+
+        // Delete model-b (not the active engine)
+        try await composite.deleteModel("model-b")
+
+        let active = await composite.activeModel()
+        #expect(active == "model-a")
+    }
+
+    // MARK: - Status after cross-engine switch
+
+    @Test("After switching engines, old engine is unloaded and reports downloaded")
+    func switchEnginesUnloadsOldEngineStatus() async throws {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a")], activeModel: "model-a")
+        let engineB = MockTranscriptionEngine(models: [makeModel("model-b")])
+
+        let composite = CompositeTranscriptionEngine(engines: [engineA, engineB])
+
+        // Start with engine A active
+        try await composite.loadModel("model-a")
+        #expect(await composite.modelStatus("model-a") == .active)
+
+        // Switch to engine B — engine A should be unloaded
+        try await composite.loadModel("model-b")
+
+        // Engine B's model should be .active
+        #expect(await composite.modelStatus("model-b") == .active)
+
+        // Engine A was unloaded, so it reports .downloaded (not .active)
+        let statusA = await composite.modelStatus("model-a")
+        #expect(statusA == .downloaded)
+    }
+
+    // MARK: - Cross-engine unload on switch
+
+    @Test("Loading model on different engine unloads the previous engine")
+    func loadModelUnloadsPreviousEngine() async throws {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a")], activeModel: "model-a")
+        let engineB = MockTranscriptionEngine(models: [makeModel("model-b")])
+
+        let composite = CompositeTranscriptionEngine(engines: [engineA, engineB])
+        try await composite.loadModel("model-a")
+
+        // Engine A has model-a loaded
+        let engineAActiveBefore = await engineA.activeModel()
+        #expect(engineAActiveBefore == "model-a")
+
+        // Switch to engine B — should unload engine A
+        try await composite.loadModel("model-b")
+
+        let engineAActiveAfter = await engineA.activeModel()
+        #expect(engineAActiveAfter == nil)
+
+        let engineBActive = await engineB.activeModel()
+        #expect(engineBActive == "model-b")
+    }
+
+    @Test("switchModel across engines unloads the previous engine")
+    func switchModelUnloadsPreviousEngine() async throws {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a")], activeModel: "model-a")
+        let engineB = MockTranscriptionEngine(models: [makeModel("model-b")])
+
+        let composite = CompositeTranscriptionEngine(engines: [engineA, engineB])
+        try await composite.loadModel("model-a")
+
+        // Switch to model-b on engine B
+        try await composite.switchModel(to: "model-b")
+
+        // Engine A should be unloaded
+        let engineAActive = await engineA.activeModel()
+        #expect(engineAActive == nil)
+
+        // Engine B should be active
+        let compositeActive = await composite.activeModel()
+        #expect(compositeActive == "model-b")
+    }
+
+    // MARK: - Bug 1 + Transcription interaction
+
+    @Test("Transcription works with old engine while new download is in progress")
+    func transcriptionWorksDuringDownload() async throws {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a")], activeModel: "model-a")
+        let engineB = MockTranscriptionEngine(models: [makeModel("model-b")])
+        await engineB.setDownloadBehavior(.controlled)
+
+        let composite = CompositeTranscriptionEngine(engines: [engineA, engineB])
+        try await composite.loadModel("model-a")
+
+        // Start download of model-b (won't complete)
+        let stream = await composite.downloadModel(makeModel("model-b"))
+
+        // Drain available progress
+        var iterator = stream.makeAsyncIterator()
+        _ = try await iterator.next()
+
+        // Transcription should route to engine A
+        let result = try await composite.transcribe([Float](repeating: 0, count: 100), language: .autoDetect)
+        #expect(result.text == "mock")
+
+        // Cleanup
+        await engineB.finishDownload()
+        while let _ = try await iterator.next() { }
+    }
+
+    // MARK: - Routing basics
+
+    @Test("Available models aggregates from all engines")
+    func availableModelsAggregates() async {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a")])
+        let engineB = MockTranscriptionEngine(models: [makeModel("model-b"), makeModel("model-c")])
+
+        let composite = CompositeTranscriptionEngine(engines: [engineA, engineB])
+        let models = await composite.availableModels()
+
+        #expect(models.count == 3)
+        #expect(models.map(\.id) == ["model-a", "model-b", "model-c"])
+    }
+
+    @Test("Download for unknown model returns error stream")
+    func downloadUnknownModelReturnsError() async {
+        let engine = MockTranscriptionEngine(models: [makeModel("model-a")])
+        let composite = CompositeTranscriptionEngine(engines: [engine])
+
+        let stream = await composite.downloadModel(makeModel("unknown"))
+        do {
+            for try await _ in stream { }
+            Issue.record("Expected error for unknown model")
+        } catch let error as WisprError {
+            if case .modelDownloadFailed(let msg) = error {
+                #expect(msg.contains("unknown"))
+            } else {
+                Issue.record("Expected modelDownloadFailed, got \(error)")
+            }
+        } catch {
+            Issue.record("Expected WisprError, got \(error)")
+        }
+    }
+
+    @Test("Transcription throws when no engine is active")
+    func transcriptionThrowsWhenNoActiveEngine() async {
+        let engine = MockTranscriptionEngine(models: [makeModel("model-a")])
+        let composite = CompositeTranscriptionEngine(engines: [engine])
+
+        do {
+            _ = try await composite.transcribe([Float](repeating: 0, count: 100), language: .autoDetect)
+            Issue.record("Expected modelNotDownloaded error")
+        } catch let error as WisprError {
+            #expect(error == .modelNotDownloaded)
+        } catch {
+            Issue.record("Expected WisprError, got \(error)")
+        }
+    }
+
+    @Test("Successful download switches active engine and enables transcription")
+    func successfulDownloadEnablesTranscription() async throws {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a")])
+        let engineB = MockTranscriptionEngine(models: [makeModel("model-b")])
+        // engineB defaults to succeedImmediately
+
+        let composite = CompositeTranscriptionEngine(engines: [engineA, engineB])
+
+        let stream = await composite.downloadModel(makeModel("model-b"))
+        for try await _ in stream { }
+
+        let active = await composite.activeModel()
+        #expect(active == "model-b")
+
+        let result = try await composite.transcribe([Float](repeating: 0, count: 100), language: .autoDetect)
+        #expect(result.text == "mock")
+    }
+}


### PR DESCRIPTION
- Add **ParakeetService** actor wrapping FluidAudio 0.7.9+ for both Parakeet V3 (batch, multilingual) and Parakeet EOU 120M (streaming with end-of-utterance detection). Supports download with file-count progress polling, model loading with offline cache support for EOU, switching between V3 and EOU, deletion with cache cleanup, and reload with exponential backoff retry.
- Add **CompositeTranscriptionEngine** actor that aggregates multiple TranscriptionEngine backends behind a single interface, routing each operation to the engine that owns the requested model. The composite defers activeEngineIndex updates until downloads complete successfully, unloads the previous backend on cross-engine switches to avoid multi-GB memory spikes, and clears the active engine on model deletion without auto-reactivating stale backends.
- Add `unloadCurrentModel()` to the **TranscriptionEngine protocol** so the composite can release a backend's memory without deleting its files. Implemented in WhisperService and ParakeetService.
- Wire CompositeTranscriptionEngine into **wisprApp** as the app's engine, replacing the direct WhisperService instantiation.
- Add **CompositeTranscriptionEngineTests** (13 tests) with a mock engine covering download deferral, download failure, cross-engine unload, delete fallback, status reporting, and model routing.