### PR TITLE
Add audio feedback sounds for recording start/stop

### DIFF
--- a/wispr/Services/StateManager.swift
+++ b/wispr/Services/StateManager.swift
@@ -212,6 +212,9 @@ final class StateManager {
                     userInfo: [.announcement: "Speech ended, processing"]
                 )
 
+                // Audio feedback so the user knows EOU was detected
+                NSSound(named: "Bottle")?.play()
+
                 guard !finalResult.text.isEmpty else {
                     await self.resetToIdle()
                     return
@@ -307,6 +310,9 @@ final class StateManager {
         appState = .recording
         errorMessage = nil
 
+        // Audio feedback so the user knows recording has started
+        NSSound(named: "Blow")?.play()
+
         // Requirement 17.3, 17.11: Announce state change to assistive technologies
         NSAccessibility.post(
             element: NSApp as Any,
@@ -364,6 +370,9 @@ final class StateManager {
 
         // Requirement 3.6: Transition to processing
         appState = .processing
+
+        // Audio feedback so the user knows recording has stopped
+        NSSound(named: "Bottle")?.play()
 
         // Requirement 17.3, 17.11: Announce state change to assistive technologies
         NSAccessibility.post(


### PR DESCRIPTION
## Summary

Adds system sound notifications to give users audible confirmation of recording state changes, especially useful in hands-free mode where there's no key-release to signal the end of recording.

## Changes

- Play **Blow** sound when recording starts (`beginRecording`)
- Play **Bottle** sound when recording stops (`endRecording`)
- Play **Bottle** sound when EOU auto-stop is triggered (hands-free mode)

All three use built-in macOS system sounds (`NSSound`), so no additional audio files are needed.

## Why

Without audio feedback, users have no way to know when Wispr starts or stops listening — especially in hands-free mode where EOU detection can stop recording automatically. This was confusing during testing as I couldn't tell if the app was still recording or had already stopped.

## Testing

- Tested on macOS 15 (Apple Silicon)
- Verified sounds play correctly for both push-to-talk and hands-free modes
- Verified EOU auto-stop plays the stop sound
- 1 file changed, 9 insertions