### PR TITLE
perf(models): make model loading idempotent to avoid CoreML recompilation

### DIFF
--- a/Sources/WisprCore/Services/CompositeTranscriptionEngine.swift
+++ b/Sources/WisprCore/Services/CompositeTranscriptionEngine.swift
@@ -96,6 +96,11 @@ public actor CompositeTranscriptionEngine: TranscriptionEngine {
             throw WisprError.modelLoadFailed("No engine found for model \(modelName)")
         }
 
+        // Already loaded on the right engine — skip the unload/reload cycle.
+        if activeEngineIndex == idx, await engines[idx].activeModel() == modelName {
+            return
+        }
+
         // Unload the previous engine to free memory before loading the new one.
         if let currentIdx = activeEngineIndex, currentIdx != idx {
             await engines[currentIdx].unloadCurrentModel()

--- a/Sources/WisprCore/Services/ParakeetService.swift
+++ b/Sources/WisprCore/Services/ParakeetService.swift
@@ -341,6 +341,13 @@ extension ParakeetService: TranscriptionEngine {
     }
 
     public func loadModel(_ modelName: String) async throws {
+        // Skip redundant reloads. Re-initializing the ASR manager re-runs CoreML
+        // compilation and writes to disk. If the requested model is already
+        // loaded, there is nothing to do.
+        if activeModelName == modelName, isModelLoaded(modelName) {
+            Log.whisperService.debug("ParakeetService — '\(modelName)' already loaded, skipping")
+            return
+        }
         Log.whisperService.debug("ParakeetService — loadModel starting for \(modelName)")
         do {
             if modelName == ModelInfo.KnownID.parakeetEou {
@@ -356,12 +363,25 @@ extension ParakeetService: TranscriptionEngine {
     }
 
     public func switchModel(to modelName: String) async throws {
+        // Already active with a live manager — nothing to do.
+        if activeModelName == modelName, isModelLoaded(modelName) {
+            Log.whisperService.debug("ParakeetService — '\(modelName)' already active, skipping")
+            return
+        }
         if modelName == ModelInfo.KnownID.parakeetEou {
             await unload()
         } else {
             unloadEou()
         }
         try await loadModel(modelName)
+    }
+
+    /// Whether the in-memory manager for `modelName` is currently loaded.
+    private func isModelLoaded(_ modelName: String) -> Bool {
+        if modelName == ModelInfo.KnownID.parakeetEou {
+            return eouManager != nil
+        }
+        return asrManager != nil
     }
 
     public func unloadCurrentModel() async {

--- a/Sources/WisprCore/Services/WhisperService.swift
+++ b/Sources/WisprCore/Services/WhisperService.swift
@@ -290,6 +290,14 @@ public actor WhisperService {
     /// - Parameter modelName: The name of the model to load
     /// - Throws: WisprError.modelLoadFailed if loading fails
     public func loadModel(_ modelName: String) async throws {
+        // Skip redundant reloads. Recreating the WhisperKit instance re-runs
+        // CoreML/ANE compilation and the prewarm pass, which is expensive and
+        // writes hundreds of MB to disk. If the requested model is already
+        // loaded, there is nothing to do.
+        if whisperKit != nil, activeModelName == modelName {
+            Log.whisperService.debug("loadModel — '\(modelName)' already loaded, skipping reload")
+            return
+        }
         Log.whisperService.debug("loadModel — loading '\(modelName)'")
         do {
             let config = WhisperKitConfig(
@@ -309,6 +317,12 @@ public actor WhisperService {
     ///
     /// Requirement 7.6: Allow switching between downloaded models.
     public func switchModel(to modelName: String) async throws {
+        // Already active with a live instance — avoid a pointless unload/reload
+        // that would re-trigger CoreML compilation.
+        if whisperKit != nil, activeModelName == modelName {
+            Log.whisperService.debug("switchModel — '\(modelName)' already active, skipping")
+            return
+        }
         whisperKit = nil
         activeModelName = nil
         try await loadModel(modelName)

--- a/wisprTests/CompositeTranscriptionEngineTests.swift
+++ b/wisprTests/CompositeTranscriptionEngineTests.swift
@@ -18,6 +18,9 @@ actor MockTranscriptionEngine: TranscriptionEngine {
     private var _activeModel: String?
     private var downloadBehavior: DownloadBehavior = .succeedImmediately
 
+    /// Number of times `loadModel` was invoked (for idempotency assertions).
+    private(set) var loadModelCallCount = 0
+
     enum DownloadBehavior {
         case succeedImmediately
         case failWith(Error)
@@ -86,6 +89,7 @@ actor MockTranscriptionEngine: TranscriptionEngine {
     }
 
     func loadModel(_ modelName: String) async throws {
+        loadModelCallCount += 1
         _activeModel = modelName
     }
 
@@ -143,6 +147,35 @@ private func makeModel(_ id: String) -> ModelInfo {
 
 @Suite("CompositeTranscriptionEngine Tests", .serialized)
 struct CompositeTranscriptionEngineTests {
+
+    // MARK: - Idempotent loading (avoid redundant CoreML recompilation)
+
+    @Test("Reloading the already-active model does not re-invoke the engine")
+    func loadModelIsIdempotentForActiveModel() async throws {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a")])
+        let composite = CompositeTranscriptionEngine(engines: [engineA])
+
+        try await composite.loadModel("model-a")
+        try await composite.loadModel("model-a")
+        try await composite.loadModel("model-a")
+
+        let count = await engineA.loadModelCallCount
+        #expect(count == 1, "loadModel should be a no-op when the model is already active")
+        #expect(await composite.activeModel() == "model-a")
+    }
+
+    @Test("Switching to a different model then back reloads as needed")
+    func loadModelReloadsWhenModelChanges() async throws {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a"), makeModel("model-a2")])
+        let composite = CompositeTranscriptionEngine(engines: [engineA])
+
+        try await composite.loadModel("model-a")
+        try await composite.loadModel("model-a2")  // different model — must reload
+
+        let count = await engineA.loadModelCallCount
+        #expect(count == 2)
+        #expect(await composite.activeModel() == "model-a2")
+    }
 
     // MARK: - Bug 1: activeEngineIndex deferred until download succeeds
 


### PR DESCRIPTION
Closes #69

  loadModel/switchModel recreated the engine instance even when the requested model was already active, re-running CoreML/ANE compilation and the prewarm pass (hundreds of MB written to disk each time).

  This makes loading idempotent in WhisperService and ParakeetService, and short-circuits CompositeTranscriptionEngine.loadModel when the model is already active on the right engine. Adds unit tests asserting the underlying engine is not re-invoked for the already-active model.