### PR TITLE
feat(meeting): detect meeting start and offer one-click transcription

### DIFF
--- a/Sources/WisprApp/Services/AudioEngine.swift
+++ b/Sources/WisprApp/Services/AudioEngine.swift
@@ -311,18 +311,7 @@ actor AudioEngine {
     
     /// Returns the system default audio input device ID.
     private func getDefaultInputDeviceID() -> AudioDeviceID? {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultInputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var deviceID: AudioDeviceID = 0
-        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
-        let status = AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
-        )
-        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
-        return deviceID
+        CoreAudioDevice.defaultInputDeviceID()
     }
 
     
@@ -400,111 +389,5 @@ actor AudioEngine {
         
         // Also yield raw audio chunks for streaming transcription (EOU monitoring)
         audioContinuation?.yield(bufferData)
-    }
-}
-
-// MARK: - CoreAudio Device Helper
-
-/// Lightweight wrapper around an AudioDeviceID that provides idiomatic property access
-nonisolated private struct CoreAudioDevice: Sendable {
-    let id: AudioDeviceID
-    
-    nonisolated var hasInputStreams: Bool {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyStreams,
-            mScope: kAudioDevicePropertyScopeInput,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var size: UInt32 = 0
-        let status = AudioObjectGetPropertyDataSize(id, &address, 0, nil, &size)
-        return status == noErr && size > 0
-    }
-    
-    nonisolated var name: String? {
-        getStringProperty(kAudioObjectPropertyName)
-    }
-    
-    nonisolated var uid: String? {
-        getStringProperty(kAudioDevicePropertyDeviceUID)
-    }
-
-    /// Whether this aggregate device is marked as private (created internally by AVAudioEngine).
-    /// User-created aggregates from Audio MIDI Setup are not private.
-    nonisolated var isPrivateAggregate: Bool {
-        guard transportType == kAudioDeviceTransportTypeAggregate else { return false }
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioAggregateDevicePropertyComposition,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var size: UInt32 = 0
-        guard AudioObjectGetPropertyDataSize(id, &address, 0, nil, &size) == noErr, size > 0 else { return false }
-        var dict: CFDictionary?
-        let status = withUnsafeMutablePointer(to: &dict) { ptr in
-            AudioObjectGetPropertyData(id, &address, 0, nil, &size, ptr)
-        }
-        guard status == noErr,
-              let composition = dict as? [String: Any] else { return false }
-        // kAudioAggregateDeviceIsPrivateKey == "priv"
-        if let isPrivate = composition["priv"] as? Int, isPrivate == 1 {
-            return true
-        }
-        return false
-    }
-
-    /// The transport type of the device (USB, Bluetooth, Built-In, etc.)
-    nonisolated var transportType: UInt32 {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyTransportType,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var value: UInt32 = 0
-        var size = UInt32(MemoryLayout<UInt32>.size)
-        let status = AudioObjectGetPropertyData(id, &address, 0, nil, &size, &value)
-        return status == noErr ? value : 0
-    }
-
-    /// The device's current nominal sample rate as reported by CoreAudio.
-    nonisolated var nominalSampleRate: Double? {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyNominalSampleRate,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var rate: Float64 = 0
-        var size = UInt32(MemoryLayout<Float64>.size)
-        let status = AudioObjectGetPropertyData(id, &address, 0, nil, &size, &rate)
-        return status == noErr ? rate : nil
-    }
-
-    /// Number of input channels on this device.
-    nonisolated var inputChannelCount: UInt32 {
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioDevicePropertyStreamConfiguration,
-            mScope: kAudioDevicePropertyScopeInput,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var size: UInt32 = 0
-        guard AudioObjectGetPropertyDataSize(id, &address, 0, nil, &size) == noErr, size > 0 else { return 0 }
-        let rawPointer = UnsafeMutableRawPointer.allocate(byteCount: Int(size), alignment: MemoryLayout<AudioBufferList>.alignment)
-        defer { rawPointer.deallocate() }
-        let bufferListPointer = rawPointer.bindMemory(to: AudioBufferList.self, capacity: 1)
-        guard AudioObjectGetPropertyData(id, &address, 0, nil, &size, bufferListPointer) == noErr else { return 0 }
-        let bufferList = UnsafeMutableAudioBufferListPointer(bufferListPointer)
-        return bufferList.reduce(0) { $0 + $1.mNumberChannels }
-    }
-    
-    nonisolated private func getStringProperty(_ selector: AudioObjectPropertySelector) -> String? {
-        var address = AudioObjectPropertyAddress(
-            mSelector: selector,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
-        var value: Unmanaged<CFString>?
-        var size = UInt32(MemoryLayout<Unmanaged<CFString>>.size)
-        let status = AudioObjectGetPropertyData(id, &address, 0, nil, &size, &value)
-        guard status == noErr else { return nil }
-        return value?.takeUnretainedValue() as String?
     }
 }

--- a/Sources/WisprApp/Services/AudioInputActivityMonitor.swift
+++ b/Sources/WisprApp/Services/AudioInputActivityMonitor.swift
@@ -20,10 +20,12 @@ import os
 protocol InputActivityMonitoring: Sendable {
     /// Starts observing input-device activity.
     ///
-    /// The `onChange` closure is invoked whenever the "in use" state changes,
-    /// and once immediately with the current state to establish a baseline.
-    /// It may be called from an arbitrary isolation context.
-    func start(onChange: @escaping @Sendable (Bool) -> Void) async
+    /// `onChange` receives the current "in use" state and whether the emission
+    /// is a *baseline* seed rather than a real transition. Baseline emissions
+    /// happen once when monitoring starts and again whenever the default input
+    /// device changes; consumers must seed their state from them but must never
+    /// treat them as a rising edge. It may be called from an arbitrary context.
+    func start(onChange: @escaping @Sendable (_ isRunning: Bool, _ isBaseline: Bool) -> Void) async
 
     /// Stops observing and releases all CoreAudio listeners.
     func stop() async
@@ -49,17 +51,17 @@ actor AudioInputActivityMonitor: InputActivityMonitoring {
     private var defaultDeviceListenerBlock: AudioObjectPropertyListenerBlock?
 
     /// Consumer callback; only read/written inside the actor.
-    private var onChange: (@Sendable (Bool) -> Void)?
+    private var onChange: (@Sendable (Bool, Bool) -> Void)?
 
     // MARK: - InputActivityMonitoring
 
-    func start(onChange: @escaping @Sendable (Bool) -> Void) {
+    func start(onChange: @escaping @Sendable (Bool, Bool) -> Void) {
         self.onChange = onChange
         attachDefaultDeviceChangeListener()
         attachToDefaultInput()
-        // Emit the current state so the consumer has a baseline and does not
-        // treat an already-in-use device as a fresh rising edge.
-        onChange(Self.readIsRunning(deviceID))
+        // Seed the consumer with the current state so an already-in-use device
+        // is not mistaken for a fresh rising edge.
+        emitCurrentState(isBaseline: true)
     }
 
     func stop() {
@@ -71,29 +73,38 @@ actor AudioInputActivityMonitor: InputActivityMonitoring {
 
     // MARK: - Listener Callbacks (hopped back onto the actor)
 
-    /// The observed device's running-somewhere flag changed.
+    /// The observed device's running-somewhere flag changed — a real transition.
     private func runningStateChanged() {
-        onChange?(Self.readIsRunning(deviceID))
+        emitCurrentState(isBaseline: false)
     }
 
-    /// The system default input device changed — move the running listener to it.
+    /// The system default input device changed — move the running listener to
+    /// it and re-seed, so a device switch mid-call is not read as a rising edge.
     private func defaultInputDeviceChanged() {
         detachRunningListener()
         attachToDefaultInput()
-        onChange?(Self.readIsRunning(deviceID))
+        emitCurrentState(isBaseline: true)
+    }
+
+    /// Reads the current running state of the observed device and forwards it.
+    private func emitCurrentState(isBaseline: Bool) {
+        let running =
+            deviceID != AudioObjectID(kAudioObjectUnknown)
+            ? CoreAudioDevice(id: deviceID).isRunningSomewhere
+            : false
+        onChange?(running, isBaseline)
     }
 
     // MARK: - Listener Management (actor-isolated)
 
     private func attachToDefaultInput() {
-        let device = Self.defaultInputDevice()
-        guard device != AudioObjectID(kAudioObjectUnknown) else {
+        guard let device = CoreAudioDevice.defaultInputDeviceID() else {
             Log.audioEngine.warning("AudioInputActivityMonitor — no default input device")
             return
         }
         deviceID = device
 
-        var address = Self.runningAddress()
+        var address = runningAddress()
         let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
             guard let self else { return }
             Task { await self.runningStateChanged() }
@@ -113,13 +124,13 @@ actor AudioInputActivityMonitor: InputActivityMonitoring {
         guard let block = runningListenerBlock,
             deviceID != AudioObjectID(kAudioObjectUnknown)
         else { return }
-        var address = Self.runningAddress()
+        var address = runningAddress()
         AudioObjectRemovePropertyListenerBlock(deviceID, &address, nil, block)
         runningListenerBlock = nil
     }
 
     private func attachDefaultDeviceChangeListener() {
-        var address = Self.defaultInputAddress()
+        var address = defaultInputAddress()
         let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
             guard let self else { return }
             Task { await self.defaultInputDeviceChanged() }
@@ -137,47 +148,27 @@ actor AudioInputActivityMonitor: InputActivityMonitoring {
 
     private func detachDefaultDeviceChangeListener() {
         guard let block = defaultDeviceListenerBlock else { return }
-        var address = Self.defaultInputAddress()
+        var address = defaultInputAddress()
         AudioObjectRemovePropertyListenerBlock(
             AudioObjectID(kAudioObjectSystemObject), &address, nil, block)
         defaultDeviceListenerBlock = nil
     }
 
-    // MARK: - CoreAudio Helpers
+    // MARK: - Property Addresses
 
-    /// Fresh property address for the default input device on the system object.
-    private nonisolated static func defaultInputAddress() -> AudioObjectPropertyAddress {
+    /// Property address for the default input device on the system object.
+    private func defaultInputAddress() -> AudioObjectPropertyAddress {
         AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDefaultInputDevice,
             mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain)
     }
 
-    /// Fresh property address for a device's "is running somewhere" flag.
-    private nonisolated static func runningAddress() -> AudioObjectPropertyAddress {
+    /// Property address for a device's "is running somewhere" flag.
+    private func runningAddress() -> AudioObjectPropertyAddress {
         AudioObjectPropertyAddress(
             mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
             mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain)
-    }
-
-    /// Resolves the current default input device, or `kAudioObjectUnknown`.
-    private nonisolated static func defaultInputDevice() -> AudioObjectID {
-        var address = defaultInputAddress()
-        var device = AudioObjectID(kAudioObjectUnknown)
-        var size = UInt32(MemoryLayout<AudioObjectID>.size)
-        let status = AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &device)
-        return status == noErr ? device : AudioObjectID(kAudioObjectUnknown)
-    }
-
-    /// Reads whether `device` is currently in use by any process.
-    private nonisolated static func readIsRunning(_ device: AudioObjectID) -> Bool {
-        guard device != AudioObjectID(kAudioObjectUnknown) else { return false }
-        var address = runningAddress()
-        var value: UInt32 = 0
-        var size = UInt32(MemoryLayout<UInt32>.size)
-        let status = AudioObjectGetPropertyData(device, &address, 0, nil, &size, &value)
-        return status == noErr && value != 0
     }
 }

--- a/Sources/WisprApp/Services/AudioInputActivityMonitor.swift
+++ b/Sources/WisprApp/Services/AudioInputActivityMonitor.swift
@@ -1,0 +1,176 @@
+//
+//  AudioInputActivityMonitor.swift
+//  wispr
+//
+//  Low-level CoreAudio monitor that reports when the system's default audio
+//  input device starts or stops being used by *any* process.
+//
+//  Used by MeetingDetectionService to detect when a meeting begins (a
+//  conferencing app starts using the microphone) without maintaining a list of
+//  known applications.
+//
+
+import CoreAudio
+import Foundation
+import WisprCore
+import os
+
+/// Abstraction over "the default input device is / is not in use", so the
+/// coordinating service can be unit-tested with a fake.
+protocol InputActivityMonitoring: AnyObject, Sendable {
+    /// Starts observing input-device activity.
+    ///
+    /// The `onChange` closure is invoked whenever the "in use" state changes,
+    /// and once immediately with the current state to establish a baseline.
+    /// It may be called on an arbitrary queue.
+    nonisolated func start(onChange: @escaping @Sendable (Bool) -> Void)
+
+    /// Stops observing and releases all CoreAudio listeners.
+    nonisolated func stop()
+}
+
+/// Observes `kAudioDevicePropertyDeviceIsRunningSomewhere` on the current
+/// default input device.
+///
+/// **Concurrency:** every CoreAudio call and all mutable state are confined to
+/// a single private serial queue. CoreAudio listener blocks are registered
+/// against that same queue, so they never run concurrently with `start` /
+/// `stop` work. The type is `@unchecked Sendable` because this confinement is a
+/// runtime discipline the compiler cannot prove.
+nonisolated final class AudioInputActivityMonitor: InputActivityMonitoring, @unchecked Sendable {
+
+    private let queue = DispatchQueue(label: "com.stormacq.mac.wispr.meeting-detection")
+
+    /// The input device currently being observed.
+    private var deviceID = AudioObjectID(kAudioObjectUnknown)
+
+    /// Listener on the observed device's running-somewhere property.
+    private var runningListenerBlock: AudioObjectPropertyListenerBlock?
+
+    /// Listener on the system object's default-input-device property.
+    private var defaultDeviceListenerBlock: AudioObjectPropertyListenerBlock?
+
+    /// Consumer callback; only read/written on `queue`.
+    private var onChange: (@Sendable (Bool) -> Void)?
+
+    // MARK: - InputActivityMonitoring
+
+    func start(onChange: @escaping @Sendable (Bool) -> Void) {
+        queue.async {
+            self.onChange = onChange
+            self.attachDefaultDeviceChangeListener()
+            self.attachToDefaultInput()
+            // Emit the current state so the consumer has a baseline and does not
+            // treat an already-in-use device as a fresh rising edge.
+            onChange(Self.readIsRunning(self.deviceID))
+        }
+    }
+
+    func stop() {
+        queue.sync {
+            self.detachRunningListener()
+            self.detachDefaultDeviceChangeListener()
+            self.onChange = nil
+            self.deviceID = AudioObjectID(kAudioObjectUnknown)
+        }
+    }
+
+    // MARK: - Listener Management (all on `queue`)
+
+    private func attachToDefaultInput() {
+        let device = Self.defaultInputDevice()
+        guard device != AudioObjectID(kAudioObjectUnknown) else {
+            Log.audioEngine.warning("AudioInputActivityMonitor — no default input device")
+            return
+        }
+        deviceID = device
+
+        var address = Self.runningAddress()
+        let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            guard let self else { return }
+            self.onChange?(Self.readIsRunning(self.deviceID))
+        }
+        let status = AudioObjectAddPropertyListenerBlock(device, &address, queue, block)
+        if status == noErr {
+            runningListenerBlock = block
+        } else {
+            Log.audioEngine.error(
+                "AudioInputActivityMonitor — failed to add running listener (status \(status))")
+        }
+    }
+
+    private func detachRunningListener() {
+        guard let block = runningListenerBlock,
+            deviceID != AudioObjectID(kAudioObjectUnknown)
+        else { return }
+        var address = Self.runningAddress()
+        AudioObjectRemovePropertyListenerBlock(deviceID, &address, queue, block)
+        runningListenerBlock = nil
+    }
+
+    private func attachDefaultDeviceChangeListener() {
+        var address = Self.defaultInputAddress()
+        let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            guard let self else { return }
+            // Default input device changed — move the running listener to it.
+            self.detachRunningListener()
+            self.attachToDefaultInput()
+            self.onChange?(Self.readIsRunning(self.deviceID))
+        }
+        let status = AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject), &address, queue, block)
+        if status == noErr {
+            defaultDeviceListenerBlock = block
+        } else {
+            Log.audioEngine.error(
+                "AudioInputActivityMonitor — failed to add default-device listener (status \(status))"
+            )
+        }
+    }
+
+    private func detachDefaultDeviceChangeListener() {
+        guard let block = defaultDeviceListenerBlock else { return }
+        var address = Self.defaultInputAddress()
+        AudioObjectRemovePropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject), &address, queue, block)
+        defaultDeviceListenerBlock = nil
+    }
+
+    // MARK: - CoreAudio Helpers
+
+    /// Fresh property address for the default input device on the system object.
+    private static func defaultInputAddress() -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+    }
+
+    /// Fresh property address for a device's "is running somewhere" flag.
+    private static func runningAddress() -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain)
+    }
+
+    /// Resolves the current default input device, or `kAudioObjectUnknown`.
+    private static func defaultInputDevice() -> AudioObjectID {
+        var address = defaultInputAddress()
+        var device = AudioObjectID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &device)
+        return status == noErr ? device : AudioObjectID(kAudioObjectUnknown)
+    }
+
+    /// Reads whether `device` is currently in use by any process.
+    private static func readIsRunning(_ device: AudioObjectID) -> Bool {
+        guard device != AudioObjectID(kAudioObjectUnknown) else { return false }
+        var address = runningAddress()
+        var value: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioObjectGetPropertyData(device, &address, 0, nil, &size, &value)
+        return status == noErr && value != 0
+    }
+}

--- a/Sources/WisprApp/Services/CoreAudioDevice.swift
+++ b/Sources/WisprApp/Services/CoreAudioDevice.swift
@@ -1,0 +1,164 @@
+//
+//  CoreAudioDevice.swift
+//  wispr
+//
+//  Lightweight, idiomatic wrapper around an AudioDeviceID plus the shared
+//  system-object queries (default input device resolution). Used by both
+//  AudioEngine (capture) and AudioInputActivityMonitor (meeting detection) so
+//  the CoreAudio boilerplate lives in one place.
+//
+
+import CoreAudio
+import Foundation
+
+/// Lightweight wrapper around an `AudioDeviceID` that provides idiomatic
+/// property access. `nonisolated` and `Sendable` so it can be used from any
+/// isolation domain (actors, `@MainActor`, CoreAudio callback threads).
+nonisolated struct CoreAudioDevice: Sendable {
+    let id: AudioDeviceID
+
+    // MARK: - System Object Queries
+
+    /// The system's current default input device, or `nil` if none is set.
+    static var defaultInput: CoreAudioDevice? {
+        guard let id = defaultInputDeviceID() else { return nil }
+        return CoreAudioDevice(id: id)
+    }
+
+    /// Resolves the current default input `AudioDeviceID`, or `nil`.
+    static func defaultInputDeviceID() -> AudioDeviceID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var deviceID: AudioDeviceID = 0
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &deviceID
+        )
+        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+        return deviceID
+    }
+
+    // MARK: - Device Properties
+
+    /// Whether this device is currently in use ("running") by any process.
+    var isRunningSomewhere: Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var value: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioObjectGetPropertyData(id, &address, 0, nil, &size, &value)
+        return status == noErr && value != 0
+    }
+
+    var hasInputStreams: Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreams,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        let status = AudioObjectGetPropertyDataSize(id, &address, 0, nil, &size)
+        return status == noErr && size > 0
+    }
+
+    var name: String? {
+        getStringProperty(kAudioObjectPropertyName)
+    }
+
+    var uid: String? {
+        getStringProperty(kAudioDevicePropertyDeviceUID)
+    }
+
+    /// Whether this aggregate device is marked as private (created internally by AVAudioEngine).
+    /// User-created aggregates from Audio MIDI Setup are not private.
+    var isPrivateAggregate: Bool {
+        guard transportType == kAudioDeviceTransportTypeAggregate else { return false }
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioAggregateDevicePropertyComposition,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(id, &address, 0, nil, &size) == noErr, size > 0 else {
+            return false
+        }
+        var dict: CFDictionary?
+        let status = withUnsafeMutablePointer(to: &dict) { ptr in
+            AudioObjectGetPropertyData(id, &address, 0, nil, &size, ptr)
+        }
+        guard status == noErr,
+            let composition = dict as? [String: Any]
+        else { return false }
+        // kAudioAggregateDeviceIsPrivateKey == "priv"
+        if let isPrivate = composition["priv"] as? Int, isPrivate == 1 {
+            return true
+        }
+        return false
+    }
+
+    /// The transport type of the device (USB, Bluetooth, Built-In, etc.)
+    var transportType: UInt32 {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyTransportType,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var value: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        let status = AudioObjectGetPropertyData(id, &address, 0, nil, &size, &value)
+        return status == noErr ? value : 0
+    }
+
+    /// The device's current nominal sample rate as reported by CoreAudio.
+    var nominalSampleRate: Double? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyNominalSampleRate,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var rate: Float64 = 0
+        var size = UInt32(MemoryLayout<Float64>.size)
+        let status = AudioObjectGetPropertyData(id, &address, 0, nil, &size, &rate)
+        return status == noErr ? rate : nil
+    }
+
+    /// Number of input channels on this device.
+    var inputChannelCount: UInt32 {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(id, &address, 0, nil, &size) == noErr, size > 0 else {
+            return 0
+        }
+        let rawPointer = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(size), alignment: MemoryLayout<AudioBufferList>.alignment)
+        defer { rawPointer.deallocate() }
+        let bufferListPointer = rawPointer.bindMemory(to: AudioBufferList.self, capacity: 1)
+        guard AudioObjectGetPropertyData(id, &address, 0, nil, &size, bufferListPointer) == noErr
+        else { return 0 }
+        let bufferList = UnsafeMutableAudioBufferListPointer(bufferListPointer)
+        return bufferList.reduce(0) { $0 + $1.mNumberChannels }
+    }
+
+    private func getStringProperty(_ selector: AudioObjectPropertySelector) -> String? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var value: Unmanaged<CFString>?
+        var size = UInt32(MemoryLayout<Unmanaged<CFString>>.size)
+        let status = AudioObjectGetPropertyData(id, &address, 0, nil, &size, &value)
+        guard status == noErr else { return nil }
+        return value?.takeUnretainedValue() as String?
+    }
+}

--- a/Sources/WisprApp/Services/MeetingDetectionService.swift
+++ b/Sources/WisprApp/Services/MeetingDetectionService.swift
@@ -1,0 +1,157 @@
+//
+//  MeetingDetectionService.swift
+//  wispr
+//
+//  Coordinates CoreAudio input-activity detection with an actionable local
+//  notification, so the user is prompted to start meeting transcription when a
+//  meeting begins.
+//
+
+import Foundation
+import Observation
+import WisprCore
+import os
+
+/// Watches for the start of a meeting (another process using the microphone)
+/// and posts a notification inviting the user to start transcription.
+///
+/// The heavy lifting lives behind two protocols (`InputActivityMonitoring`,
+/// `MeetingNotifying`) so this coordination logic is fully unit-testable.
+@MainActor
+final class MeetingDetectionService {
+
+    // MARK: - Dependencies
+
+    private let settingsStore: SettingsStore
+    private let monitor: any InputActivityMonitoring
+    private let notifier: any MeetingNotifying
+
+    /// Returns `true` when Wispr itself is using the microphone (dictation or an
+    /// active meeting recording), so self-triggered activity is ignored.
+    /// Injected by the app delegate; defaults to "not using".
+    var isSelfUsingMicrophone: @MainActor () -> Bool = { false }
+
+    // MARK: - Configuration
+
+    /// Minimum interval between two meeting-detected notifications.
+    private let cooldown: TimeInterval
+
+    // MARK: - State
+
+    private var isMonitoring = false
+    private var lastRunningState = false
+    private var lastNotificationDate: Date?
+    private var settingsObservationTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    init(
+        settingsStore: SettingsStore,
+        notifier: any MeetingNotifying,
+        monitor: any InputActivityMonitoring = AudioInputActivityMonitor(),
+        cooldown: TimeInterval = 5 * 60
+    ) {
+        self.settingsStore = settingsStore
+        self.notifier = notifier
+        self.monitor = monitor
+        self.cooldown = cooldown
+    }
+
+    // MARK: - Lifecycle
+
+    /// Starts observing the setting and, if enabled, begins monitoring.
+    func start() {
+        applyMonitoringState()
+        observeSettings()
+    }
+
+    /// Stops all observation and monitoring.
+    func stop() {
+        settingsObservationTask?.cancel()
+        settingsObservationTask = nil
+        stopMonitoring()
+    }
+
+    // MARK: - Settings Observation
+
+    private func observeSettings() {
+        settingsObservationTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                await withCheckedContinuation { continuation in
+                    withObservationTracking {
+                        _ = self.settingsStore.meetingDetectionEnabled
+                    } onChange: {
+                        continuation.resume()
+                    }
+                }
+                self.applyMonitoringState()
+            }
+        }
+    }
+
+    private func applyMonitoringState() {
+        if settingsStore.meetingDetectionEnabled {
+            startMonitoring()
+        } else {
+            stopMonitoring()
+        }
+    }
+
+    // MARK: - Monitoring
+
+    private func startMonitoring() {
+        guard !isMonitoring else { return }
+        isMonitoring = true
+        lastRunningState = false
+
+        notifier.requestAuthorization()
+
+        monitor.start { [weak self] running in
+            // Listener may fire on an arbitrary queue — hop to the main actor.
+            Task { @MainActor in
+                self?.handleActivityChange(running)
+            }
+        }
+        Log.app.debug("MeetingDetectionService — monitoring started")
+    }
+
+    private func stopMonitoring() {
+        guard isMonitoring else { return }
+        isMonitoring = false
+        monitor.stop()
+        lastRunningState = false
+        Log.app.debug("MeetingDetectionService — monitoring stopped")
+    }
+
+    // MARK: - Activity Handling
+
+    /// Handles a change in input-device activity. Internal (not private) so unit
+    /// tests can drive it directly.
+    func handleActivityChange(_ running: Bool) {
+        let wasRunning = lastRunningState
+        lastRunningState = running
+
+        // Only react to a rising edge (idle -> in use).
+        guard running, !wasRunning else { return }
+
+        // Respect the setting (it may have been disabled between events).
+        guard settingsStore.meetingDetectionEnabled else { return }
+
+        // Ignore activity caused by Wispr itself.
+        guard !isSelfUsingMicrophone() else {
+            Log.app.debug("MeetingDetectionService — activity is Wispr itself, ignoring")
+            return
+        }
+
+        // Enforce the cooldown.
+        if let last = lastNotificationDate, Date().timeIntervalSince(last) < cooldown {
+            Log.app.debug("MeetingDetectionService — within cooldown, skipping notification")
+            return
+        }
+
+        lastNotificationDate = Date()
+        notifier.postMeetingDetectedNotification()
+        Log.app.debug("MeetingDetectionService — meeting detected, notification posted")
+    }
+}

--- a/Sources/WisprApp/Services/MeetingDetectionService.swift
+++ b/Sources/WisprApp/Services/MeetingDetectionService.swift
@@ -77,14 +77,9 @@ final class MeetingDetectionService {
     private func observeSettings() {
         settingsObservationTask = Task { [weak self] in
             guard let self else { return }
-            while !Task.isCancelled {
-                await withCheckedContinuation { continuation in
-                    withObservationTracking {
-                        _ = self.settingsStore.meetingDetectionEnabled
-                    } onChange: {
-                        continuation.resume()
-                    }
-                }
+            let store = self.settingsStore
+            for await _ in store.changes(tracking: { _ = store.meetingDetectionEnabled }) {
+                if Task.isCancelled { break }
                 await self.applyMonitoringState()
             }
         }
@@ -105,12 +100,14 @@ final class MeetingDetectionService {
         isMonitoring = true
         lastRunningState = false
 
-        notifier.requestAuthorization()
+        // Await authorization before arming so a rising edge can't produce a
+        // notification the system silently drops for a not-yet-authorized app.
+        await notifier.requestAuthorization()
 
-        await monitor.start { [weak self] running in
+        await monitor.start { [weak self] running, isBaseline in
             // Listener fires from an arbitrary context — hop to the main actor.
             Task { @MainActor in
-                self?.handleActivityChange(running)
+                await self?.handleActivityChange(running, isBaseline: isBaseline)
             }
         }
         Log.app.debug("MeetingDetectionService — monitoring started")
@@ -128,7 +125,17 @@ final class MeetingDetectionService {
 
     /// Handles a change in input-device activity. Internal (not private) so unit
     /// tests can drive it directly.
-    func handleActivityChange(_ running: Bool) {
+    ///
+    /// `isBaseline` marks a seed emission (monitoring start, or a default-input
+    /// device change): it only updates `lastRunningState` and never notifies,
+    /// so an already-in-use device is not mistaken for a rising edge.
+    func handleActivityChange(_ running: Bool, isBaseline: Bool) async {
+        // Baseline emissions seed state only — never a rising edge.
+        guard !isBaseline else {
+            lastRunningState = running
+            return
+        }
+
         let wasRunning = lastRunningState
         lastRunningState = running
 
@@ -151,7 +158,7 @@ final class MeetingDetectionService {
         }
 
         lastNotificationDate = Date()
-        notifier.postMeetingDetectedNotification()
+        await notifier.postMeetingDetectedNotification()
         Log.app.debug("MeetingDetectionService — meeting detected, notification posted")
     }
 }

--- a/Sources/WisprApp/Services/MeetingNotificationService.swift
+++ b/Sources/WisprApp/Services/MeetingNotificationService.swift
@@ -15,11 +15,12 @@ import os
 /// coordinating service can be unit-tested without the notification center.
 @MainActor
 protocol MeetingNotifying: AnyObject {
-    /// Requests notification authorization if not already determined.
-    func requestAuthorization()
+    /// Requests notification authorization (awaiting the user's response) and
+    /// performs any one-time setup. Safe to call repeatedly.
+    func requestAuthorization() async
 
     /// Posts the actionable "meeting detected" notification.
-    func postMeetingDetectedNotification()
+    func postMeetingDetectedNotification() async
 }
 
 /// Concrete `MeetingNotifying` backed by `UNUserNotificationCenter`.
@@ -27,6 +28,10 @@ protocol MeetingNotifying: AnyObject {
 /// Registers a single foreground action ("Start transcription"). When the user
 /// activates the action — or taps the notification body — `onStartMeetingRequested`
 /// is invoked on the main actor.
+///
+/// Setup (delegate + notification categories) is deferred until the first
+/// `requestAuthorization()` call, so a disabled feature does no launch-time work
+/// and does not claim the notification center's single delegate slot.
 @MainActor
 final class MeetingNotificationService: NSObject, MeetingNotifying,
     UNUserNotificationCenterDelegate
@@ -42,27 +47,23 @@ final class MeetingNotificationService: NSObject, MeetingNotifying,
 
     private let center = UNUserNotificationCenter.current()
 
-    override init() {
-        super.init()
-        center.delegate = self
-        registerCategory()
-    }
+    /// Whether the delegate and notification categories have been registered.
+    private var isConfigured = false
 
     // MARK: - MeetingNotifying
 
-    func requestAuthorization() {
-        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
-            if let error {
-                Log.app.error(
-                    "MeetingNotificationService — authorization error: \(error.localizedDescription)"
-                )
-            } else {
-                Log.app.debug("MeetingNotificationService — authorization granted: \(granted)")
-            }
+    func requestAuthorization() async {
+        configureIfNeeded()
+        do {
+            let granted = try await center.requestAuthorization(options: [.alert, .sound])
+            Log.app.debug("MeetingNotificationService — authorization granted: \(granted)")
+        } catch {
+            Log.app.error(
+                "MeetingNotificationService — authorization error: \(error.localizedDescription)")
         }
     }
 
-    func postMeetingDetectedNotification() {
+    func postMeetingDetectedNotification() async {
         let content = UNMutableNotificationContent()
         content.title = "Meeting detected"
         content.body = "Start transcribing this meeting with Wispr?"
@@ -76,16 +77,25 @@ final class MeetingNotificationService: NSObject, MeetingNotifying,
             content: content,
             trigger: nil)
 
-        center.add(request) { error in
-            if let error {
-                Log.app.error(
-                    "MeetingNotificationService — failed to post notification: \(error.localizedDescription)"
-                )
-            }
+        do {
+            try await center.add(request)
+        } catch {
+            Log.app.error(
+                "MeetingNotificationService — failed to post notification: \(error.localizedDescription)"
+            )
         }
     }
 
-    // MARK: - Category Registration
+    // MARK: - One-time Setup
+
+    /// Registers the delegate and notification category the first time the
+    /// feature is enabled. Idempotent.
+    private func configureIfNeeded() {
+        guard !isConfigured else { return }
+        isConfigured = true
+        center.delegate = self
+        registerCategory()
+    }
 
     private func registerCategory() {
         let startAction = UNNotificationAction(

--- a/Sources/WisprApp/Services/MeetingNotificationService.swift
+++ b/Sources/WisprApp/Services/MeetingNotificationService.swift
@@ -1,0 +1,131 @@
+//
+//  MeetingNotificationService.swift
+//  wispr
+//
+//  Posts an actionable local notification when a meeting is detected and
+//  routes the user's action back to the meeting transcription flow.
+//
+
+import Foundation
+import UserNotifications
+import WisprCore
+import os
+
+/// Abstraction over posting the "meeting detected" notification, so the
+/// coordinating service can be unit-tested without the notification center.
+@MainActor
+protocol MeetingNotifying: AnyObject {
+    /// Requests notification authorization if not already determined.
+    func requestAuthorization()
+
+    /// Posts the actionable "meeting detected" notification.
+    func postMeetingDetectedNotification()
+}
+
+/// Concrete `MeetingNotifying` backed by `UNUserNotificationCenter`.
+///
+/// Registers a single foreground action ("Start transcription"). When the user
+/// activates the action — or taps the notification body — `onStartMeetingRequested`
+/// is invoked on the main actor.
+@MainActor
+final class MeetingNotificationService: NSObject, MeetingNotifying,
+    UNUserNotificationCenterDelegate
+{
+
+    nonisolated static let categoryIdentifier = "com.stormacq.mac.wispr.meeting-detected"
+    nonisolated static let startActionIdentifier = "START_MEETING_TRANSCRIPTION"
+    nonisolated static let notificationIdentifier =
+        "com.stormacq.mac.wispr.meeting-detected.notification"
+
+    /// Invoked on the main actor when the user asks to start transcription.
+    var onStartMeetingRequested: (@MainActor () -> Void)?
+
+    private let center = UNUserNotificationCenter.current()
+
+    override init() {
+        super.init()
+        center.delegate = self
+        registerCategory()
+    }
+
+    // MARK: - MeetingNotifying
+
+    func requestAuthorization() {
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if let error {
+                Log.app.error(
+                    "MeetingNotificationService — authorization error: \(error.localizedDescription)"
+                )
+            } else {
+                Log.app.debug("MeetingNotificationService — authorization granted: \(granted)")
+            }
+        }
+    }
+
+    func postMeetingDetectedNotification() {
+        let content = UNMutableNotificationContent()
+        content.title = "Meeting detected"
+        content.body = "Start transcribing this meeting with Wispr?"
+        content.categoryIdentifier = Self.categoryIdentifier
+        content.sound = .default
+
+        // Fixed identifier so a pending/duplicate notification coalesces rather
+        // than stacking up.
+        let request = UNNotificationRequest(
+            identifier: Self.notificationIdentifier,
+            content: content,
+            trigger: nil)
+
+        center.add(request) { error in
+            if let error {
+                Log.app.error(
+                    "MeetingNotificationService — failed to post notification: \(error.localizedDescription)"
+                )
+            }
+        }
+    }
+
+    // MARK: - Category Registration
+
+    private func registerCategory() {
+        let startAction = UNNotificationAction(
+            identifier: Self.startActionIdentifier,
+            title: "Start transcription",
+            options: [.foreground])
+
+        let category = UNNotificationCategory(
+            identifier: Self.categoryIdentifier,
+            actions: [startAction],
+            intentIdentifiers: [],
+            options: [])
+
+        center.setNotificationCategories([category])
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    /// Present the banner even though a menu-bar (accessory) app is effectively
+    /// always frontmost.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        [.banner, .sound]
+    }
+
+    /// Route the "Start transcription" action (or a tap on the notification) to
+    /// the meeting flow.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        let action = response.actionIdentifier
+        guard action == Self.startActionIdentifier
+            || action == UNNotificationDefaultActionIdentifier
+        else { return }
+
+        await MainActor.run { [weak self] in
+            self?.onStartMeetingRequested?()
+        }
+    }
+}

--- a/Sources/WisprApp/Services/SettingsStore.swift
+++ b/Sources/WisprApp/Services/SettingsStore.swift
@@ -76,6 +76,14 @@ final class SettingsStore {
         didSet { guard !isLoading else { return }; defaults.set(soundFeedbackEnabled, forKey: Keys.soundFeedbackEnabled) }
     }
 
+    // MARK: - Meeting Detection
+
+    /// When true, Wispr watches for another app using the microphone and posts a
+    /// notification inviting the user to start meeting transcription.
+    var meetingDetectionEnabled: Bool {
+        didSet { guard !isLoading else { return }; defaults.set(meetingDetectionEnabled, forKey: Keys.meetingDetectionEnabled) }
+    }
+
     // MARK: - Auto-Suffix Settings
 
     /// When true, appends `autoSuffixText` to transcribed text before insertion.
@@ -132,6 +140,7 @@ final class SettingsStore {
         static let onboardingLastStep = "onboardingLastStep"
         static let handsFreeMode = "handsFreeMode"
         static let soundFeedbackEnabled = "soundFeedbackEnabled"
+        static let meetingDetectionEnabled = "meetingDetectionEnabled"
         static let autoSuffixEnabled = "autoSuffixEnabled"
         static let autoSuffixText = "autoSuffixText"
         static let removeFillerWords = "removeFillerWords"
@@ -156,6 +165,7 @@ final class SettingsStore {
         static let onboardingLastStep: Int = 0
         static let handsFreeMode: Bool = false
         static let soundFeedbackEnabled: Bool = false
+        static let meetingDetectionEnabled: Bool = true
         static let autoSuffixEnabled: Bool = false
         static let autoSuffixText: String = " "
         static let removeFillerWords: Bool = false
@@ -184,6 +194,7 @@ final class SettingsStore {
         self.onboardingLastStep = Defaults.onboardingLastStep
         self.handsFreeMode = Defaults.handsFreeMode
         self.soundFeedbackEnabled = Defaults.soundFeedbackEnabled
+        self.meetingDetectionEnabled = Defaults.meetingDetectionEnabled
         self.autoSuffixEnabled = Defaults.autoSuffixEnabled
         self.autoSuffixText = Defaults.autoSuffixText
         self.removeFillerWords = Defaults.removeFillerWords
@@ -210,6 +221,7 @@ final class SettingsStore {
         launchAtLogin = Defaults.launchAtLogin
         handsFreeMode = Defaults.handsFreeMode
         soundFeedbackEnabled = Defaults.soundFeedbackEnabled
+        meetingDetectionEnabled = Defaults.meetingDetectionEnabled
         autoSuffixEnabled = Defaults.autoSuffixEnabled
         autoSuffixText = Defaults.autoSuffixText
         removeFillerWords = Defaults.removeFillerWords
@@ -235,6 +247,7 @@ final class SettingsStore {
         defaults.set(onboardingLastStep, forKey: Keys.onboardingLastStep)
         defaults.set(handsFreeMode, forKey: Keys.handsFreeMode)
         defaults.set(soundFeedbackEnabled, forKey: Keys.soundFeedbackEnabled)
+        defaults.set(meetingDetectionEnabled, forKey: Keys.meetingDetectionEnabled)
         defaults.set(autoSuffixEnabled, forKey: Keys.autoSuffixEnabled)
         defaults.set(autoSuffixText, forKey: Keys.autoSuffixText)
         defaults.set(removeFillerWords, forKey: Keys.removeFillerWords)
@@ -302,6 +315,10 @@ final class SettingsStore {
 
         if defaults.object(forKey: Keys.soundFeedbackEnabled) != nil {
             self.soundFeedbackEnabled = defaults.bool(forKey: Keys.soundFeedbackEnabled)
+        }
+
+        if defaults.object(forKey: Keys.meetingDetectionEnabled) != nil {
+            self.meetingDetectionEnabled = defaults.bool(forKey: Keys.meetingDetectionEnabled)
         }
 
         // Load auto-suffix settings

--- a/Sources/WisprApp/Services/SettingsStore.swift
+++ b/Sources/WisprApp/Services/SettingsStore.swift
@@ -468,3 +468,35 @@ final class SettingsStore {
         }
     }
 }
+
+// MARK: - Observation Helpers
+
+extension SettingsStore {
+
+    /// An `AsyncStream` that yields once each time any value read inside
+    /// `track` changes.
+    ///
+    /// Observation is re-armed from *within* the change handler rather than
+    /// after the consumer's async work, so a change that lands while the
+    /// consumer is awaiting is not missed — unlike a bare
+    /// `withObservationTracking` loop that only re-registers once its async body
+    /// returns. Centralizes the observation idiom that would otherwise be
+    /// duplicated across observers.
+    nonisolated func changes(
+        tracking track: @escaping @MainActor @Sendable () -> Void
+    ) -> AsyncStream<Void> {
+        AsyncStream { continuation in
+            @Sendable func arm() {
+                Task { @MainActor in
+                    withObservationTracking {
+                        track()
+                    } onChange: {
+                        continuation.yield(())
+                        arm()
+                    }
+                }
+            }
+            arm()
+        }
+    }
+}

--- a/Sources/WisprApp/UI/Settings/SettingsView.swift
+++ b/Sources/WisprApp/UI/Settings/SettingsView.swift
@@ -62,6 +62,7 @@ struct SettingsView: View {
         // Feedback section
         static let soundFeedback = "When enabled, plays audio cues when recording starts and stops"
         static let showRecordingOverlay = "When enabled, a floating overlay appears while recording"
+        static let meetingDetection = "When enabled, Wispr notifies you when another app starts using your microphone so you can start meeting transcription in one click"
 
         // General section
         static let launchAtLogin = "When enabled, Wispr starts automatically when you log in"
@@ -350,6 +351,9 @@ struct SettingsView: View {
 
             Toggle("Show Recording Overlay", isOn: $store.showRecordingOverlay)
                 .accessibilityHint(AccessibilityHints.showRecordingOverlay)
+
+            Toggle("Detect Meetings", isOn: $store.meetingDetectionEnabled)
+                .accessibilityHint(AccessibilityHints.meetingDetection)
         } header: {
             SectionHeader(
                 title: "Feedback",

--- a/Sources/WisprApp/wisprApp.swift
+++ b/Sources/WisprApp/wisprApp.swift
@@ -95,11 +95,17 @@ final class WisprAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate 
     /// Meeting audio engine for dual capture (mic + system audio).
     let meetingAudioEngine = MeetingAudioEngine()
 
+    /// Posts actionable notifications when a meeting is detected.
+    let meetingNotificationService = MeetingNotificationService()
+
     /// Central state coordinator — depends on all services above.
     private(set) var stateManager: StateManager?
 
     /// Meeting state manager for meeting transcription mode.
     private(set) var meetingStateManager: MeetingStateManager?
+
+    /// Detects meeting start via CoreAudio and drives the notification.
+    private(set) var meetingDetectionService: MeetingDetectionService?
 
     /// Menu bar status item controller.
     private var menuBarController: MenuBarController?
@@ -174,6 +180,30 @@ final class WisprAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate 
             settingsStore: settingsStore
         )
         meetingStateManager = msm
+
+        // Wire meeting detection: post a notification when another app starts
+        // using the microphone, and start transcription when the user acts on it.
+        meetingNotificationService.onStartMeetingRequested = { [weak self] in
+            guard let self, let meetingManager = self.meetingStateManager else { return }
+            Task { await meetingManager.startMeeting() }
+        }
+
+        let detection = MeetingDetectionService(
+            settingsStore: settingsStore,
+            notifier: meetingNotificationService
+        )
+        // Ignore microphone activity caused by Wispr itself (dictation or an
+        // active meeting recording) to avoid self-triggered notifications.
+        detection.isSelfUsingMicrophone = { [weak self] in
+            guard let self else { return false }
+            let dictating =
+                self.stateManager?.appState == .recording
+                || self.stateManager?.appState == .processing
+            let inMeeting = self.meetingStateManager?.meetingState == .recording
+            return dictating || inMeeting
+        }
+        detection.start()
+        meetingDetectionService = detection
 
         // Create menu bar controller (Req 5.1)
         menuBarController = MenuBarController(
@@ -298,6 +328,9 @@ final class WisprAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate 
 
         // Stop any active meeting session (synchronous — cascades via task group)
         meetingStateManager?.cancelRecording()
+
+        // Stop meeting detection monitoring.
+        meetingDetectionService?.stop()
 
         // Force UserDefaults to flush to disk before the process exits.
         settingsStore.flush()

--- a/Sources/WisprApp/wisprApp.swift
+++ b/Sources/WisprApp/wisprApp.swift
@@ -189,6 +189,18 @@ final class WisprAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate 
         // using the microphone, and start transcription when the user acts on it.
         meetingNotificationService.onStartMeetingRequested = { [weak self] in
             guard let self, let meetingManager = self.meetingStateManager else { return }
+            // Don't start a meeting while dictation is active: MeetingAudioEngine
+            // would contend with the dictation engine for the microphone. Guard
+            // here because the notification may have been posted while idle and
+            // acted on later, after dictation started.
+            let dictating =
+                self.stateManager?.appState == .recording
+                || self.stateManager?.appState == .processing
+            guard !dictating else {
+                Log.app.debug(
+                    "Start-meeting action ignored — dictation active, avoiding dual mic capture")
+                return
+            }
             Task { await meetingManager.startMeeting() }
         }
 

--- a/wispr.xcodeproj/project.pbxproj
+++ b/wispr.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		1C74D4232FA6394300208826 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 00C110112F60A00100000002 /* FluidAudio */; };
 		E4782D9F9369B23177982DC0 /* MeetingAudioEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85566A381EF49B2D8D58E9FE /* MeetingAudioEngine.swift */; };
 		D1AD12340000000000000001 /* MeetingDiarizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AD12340000000000000002 /* MeetingDiarizer.swift */; };
+		AA40000000000000000000A4 /* CoreAudioDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA4F000000000000000000F4 /* CoreAudioDevice.swift */; };
 		AA10000000000000000000A1 /* AudioInputActivityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1F000000000000000000F1 /* AudioInputActivityMonitor.swift */; };
 		AA20000000000000000000A2 /* MeetingDetectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2F000000000000000000F2 /* MeetingDetectionService.swift */; };
 		AA30000000000000000000A3 /* MeetingNotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3F000000000000000000F3 /* MeetingNotificationService.swift */; };
@@ -213,6 +214,7 @@
 		1C74D2FD2FA632B700208826 /* wisprApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wisprApp.swift; sourceTree = "<group>"; };
 		85566A381EF49B2D8D58E9FE /* MeetingAudioEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingAudioEngine.swift; sourceTree = "<group>"; };
 		D1AD12340000000000000002 /* MeetingDiarizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDiarizer.swift; sourceTree = "<group>"; };
+		AA4F000000000000000000F4 /* CoreAudioDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreAudioDevice.swift; sourceTree = "<group>"; };
 		AA1F000000000000000000F1 /* AudioInputActivityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInputActivityMonitor.swift; sourceTree = "<group>"; };
 		AA2F000000000000000000F2 /* MeetingDetectionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDetectionService.swift; sourceTree = "<group>"; };
 		AA3F000000000000000000F3 /* MeetingNotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingNotificationService.swift; sourceTree = "<group>"; };
@@ -409,6 +411,7 @@
 				1C74D2D32FA632B700208826 /* AudioEngine.swift */,
 				85566A381EF49B2D8D58E9FE /* MeetingAudioEngine.swift */,
 				D1AD12340000000000000002 /* MeetingDiarizer.swift */,
+				AA4F000000000000000000F4 /* CoreAudioDevice.swift */,
 				AA1F000000000000000000F1 /* AudioInputActivityMonitor.swift */,
 				AA2F000000000000000000F2 /* MeetingDetectionService.swift */,
 				AA3F000000000000000000F3 /* MeetingNotificationService.swift */,
@@ -762,6 +765,7 @@
 				1C74D3462FA632B700208826 /* AudioEngine.swift in Sources */,
 				E4782D9F9369B23177982DC0 /* MeetingAudioEngine.swift in Sources */,
 				D1AD12340000000000000001 /* MeetingDiarizer.swift in Sources */,
+				AA40000000000000000000A4 /* CoreAudioDevice.swift in Sources */,
 				AA10000000000000000000A1 /* AudioInputActivityMonitor.swift in Sources */,
 				AA20000000000000000000A2 /* MeetingDetectionService.swift in Sources */,
 				AA30000000000000000000A3 /* MeetingNotificationService.swift in Sources */,

--- a/wisprTests/MeetingDetectionServiceTests.swift
+++ b/wisprTests/MeetingDetectionServiceTests.swift
@@ -18,9 +18,9 @@ import Testing
 final class FakeInputActivityMonitor: InputActivityMonitoring {
     private(set) var startCount = 0
     private(set) var stopCount = 0
-    private var onChange: (@Sendable (Bool) -> Void)?
+    private var onChange: (@Sendable (Bool, Bool) -> Void)?
 
-    func start(onChange: @escaping @Sendable (Bool) -> Void) {
+    func start(onChange: @escaping @Sendable (Bool, Bool) -> Void) {
         startCount += 1
         self.onChange = onChange
     }
@@ -39,11 +39,11 @@ final class FakeMeetingNotifier: MeetingNotifying {
     private(set) var authorizationRequests = 0
     private(set) var postedCount = 0
 
-    func requestAuthorization() {
+    func requestAuthorization() async {
         authorizationRequests += 1
     }
 
-    func postMeetingDetectedNotification() {
+    func postMeetingDetectedNotification() async {
         postedCount += 1
     }
 }
@@ -104,7 +104,7 @@ struct MeetingDetectionServiceTests {
         let (service, _, notifier, _) = makeService(enabled: true)
         await service.start()
 
-        service.handleActivityChange(true)
+        await service.handleActivityChange(true, isBaseline: false)
 
         #expect(notifier.postedCount == 1)
     }
@@ -114,10 +114,45 @@ struct MeetingDetectionServiceTests {
         let (service, _, notifier, _) = makeService(enabled: true)
         await service.start()
 
-        service.handleActivityChange(true)
-        service.handleActivityChange(true)  // still running, no new edge
+        await service.handleActivityChange(true, isBaseline: false)
+        await service.handleActivityChange(true, isBaseline: false)  // still running, no new edge
 
         #expect(notifier.postedCount == 1)
+    }
+
+    @Test("baseline emission (already in use) does not post, and suppresses the next same-state edge")
+    func testBaselineSeedsWithoutNotifying() async {
+        let (service, _, notifier, _) = makeService(enabled: true)
+        await service.start()
+
+        // Monitoring starts mid-call: baseline says "running".
+        await service.handleActivityChange(true, isBaseline: true)
+        // A subsequent real callback with the same state is not a rising edge.
+        await service.handleActivityChange(true, isBaseline: false)
+
+        #expect(notifier.postedCount == 0)
+    }
+
+    @Test("rising edge after an idle baseline still posts")
+    func testRisingEdgeAfterIdleBaseline() async {
+        let (service, _, notifier, _) = makeService(enabled: true)
+        await service.start()
+
+        await service.handleActivityChange(false, isBaseline: true)  // idle baseline
+        await service.handleActivityChange(true, isBaseline: false)  // real rising edge
+
+        #expect(notifier.postedCount == 1)
+    }
+
+    @Test("device-change baseline re-seed does not post")
+    func testDeviceChangeBaselineDoesNotPost() async {
+        let (service, _, notifier, _) = makeService(enabled: true)
+        await service.start()
+
+        await service.handleActivityChange(false, isBaseline: true)  // initial idle baseline
+        await service.handleActivityChange(true, isBaseline: true)  // device switched mid-call
+
+        #expect(notifier.postedCount == 0)
     }
 
     @Test("falling then rising edge posts again after cooldown of zero")
@@ -125,9 +160,9 @@ struct MeetingDetectionServiceTests {
         let (service, _, notifier, _) = makeService(enabled: true, cooldown: 0)
         await service.start()
 
-        service.handleActivityChange(true)
-        service.handleActivityChange(false)
-        service.handleActivityChange(true)
+        await service.handleActivityChange(true, isBaseline: false)
+        await service.handleActivityChange(false, isBaseline: false)
+        await service.handleActivityChange(true, isBaseline: false)
 
         #expect(notifier.postedCount == 2)
     }
@@ -137,9 +172,9 @@ struct MeetingDetectionServiceTests {
         let (service, _, notifier, _) = makeService(enabled: true, cooldown: 5 * 60)
         await service.start()
 
-        service.handleActivityChange(true)
-        service.handleActivityChange(false)
-        service.handleActivityChange(true)  // within cooldown
+        await service.handleActivityChange(true, isBaseline: false)
+        await service.handleActivityChange(false, isBaseline: false)
+        await service.handleActivityChange(true, isBaseline: false)  // within cooldown
 
         #expect(notifier.postedCount == 1)
     }
@@ -150,7 +185,7 @@ struct MeetingDetectionServiceTests {
         await service.start()
         settings.meetingDetectionEnabled = false
 
-        service.handleActivityChange(true)
+        await service.handleActivityChange(true, isBaseline: false)
 
         #expect(notifier.postedCount == 0)
     }
@@ -161,7 +196,7 @@ struct MeetingDetectionServiceTests {
         service.isSelfUsingMicrophone = { true }
         await service.start()
 
-        service.handleActivityChange(true)
+        await service.handleActivityChange(true, isBaseline: false)
 
         #expect(notifier.postedCount == 0)
     }

--- a/wisprTests/MeetingDetectionServiceTests.swift
+++ b/wisprTests/MeetingDetectionServiceTests.swift
@@ -1,0 +1,178 @@
+//
+//  MeetingDetectionServiceTests.swift
+//  wisprTests
+//
+//  Unit tests for MeetingDetectionService using fake monitor and notifier.
+//
+
+import Foundation
+import Testing
+
+@testable import WisprApp
+
+// MARK: - Fakes
+
+/// Fake input-activity monitor that captures the `onChange` closure so tests
+/// can drive activity events synchronously.
+final class FakeInputActivityMonitor: InputActivityMonitoring, @unchecked Sendable {
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+    private var onChange: (@Sendable (Bool) -> Void)?
+
+    func start(onChange: @escaping @Sendable (Bool) -> Void) {
+        startCount += 1
+        self.onChange = onChange
+    }
+
+    func stop() {
+        stopCount += 1
+        onChange = nil
+    }
+
+    var isStarted: Bool { onChange != nil }
+}
+
+/// Fake notifier that records calls.
+@MainActor
+final class FakeMeetingNotifier: MeetingNotifying {
+    private(set) var authorizationRequests = 0
+    private(set) var postedCount = 0
+
+    func requestAuthorization() {
+        authorizationRequests += 1
+    }
+
+    func postMeetingDetectedNotification() {
+        postedCount += 1
+    }
+}
+
+// MARK: - Helpers
+
+@MainActor
+private func makeService(
+    enabled: Bool = true,
+    cooldown: TimeInterval = 5 * 60
+) -> (MeetingDetectionService, FakeInputActivityMonitor, FakeMeetingNotifier, SettingsStore) {
+    let settings = SettingsStore(
+        defaults: UserDefaults(suiteName: "test.wispr.detection.\(UUID().uuidString)")!
+    )
+    settings.meetingDetectionEnabled = enabled
+
+    let monitor = FakeInputActivityMonitor()
+    let notifier = FakeMeetingNotifier()
+    let service = MeetingDetectionService(
+        settingsStore: settings,
+        notifier: notifier,
+        monitor: monitor,
+        cooldown: cooldown
+    )
+    return (service, monitor, notifier, settings)
+}
+
+// MARK: - Tests
+
+@MainActor
+@Suite("MeetingDetectionService Tests", .serialized)
+struct MeetingDetectionServiceTests {
+
+    @Test("start() begins monitoring and requests authorization when enabled")
+    func testStartBeginsMonitoring() {
+        let (service, monitor, notifier, _) = makeService(enabled: true)
+
+        service.start()
+
+        #expect(monitor.isStarted)
+        #expect(monitor.startCount == 1)
+        #expect(notifier.authorizationRequests == 1)
+    }
+
+    @Test("start() does not monitor when the setting is disabled")
+    func testStartDisabledDoesNotMonitor() {
+        let (service, monitor, notifier, _) = makeService(enabled: false)
+
+        service.start()
+
+        #expect(monitor.isStarted == false)
+        #expect(monitor.startCount == 0)
+        #expect(notifier.authorizationRequests == 0)
+    }
+
+    @Test("rising edge posts exactly one notification")
+    func testRisingEdgePostsNotification() {
+        let (service, _, notifier, _) = makeService(enabled: true)
+        service.start()
+
+        service.handleActivityChange(true)
+
+        #expect(notifier.postedCount == 1)
+    }
+
+    @Test("no rising edge (already running) posts nothing")
+    func testNoEdgePostsNothing() {
+        let (service, _, notifier, _) = makeService(enabled: true)
+        service.start()
+
+        service.handleActivityChange(true)
+        service.handleActivityChange(true)  // still running, no new edge
+
+        #expect(notifier.postedCount == 1)
+    }
+
+    @Test("falling then rising edge posts again after cooldown of zero")
+    func testSecondEdgePostsWithNoCooldown() {
+        let (service, _, notifier, _) = makeService(enabled: true, cooldown: 0)
+        service.start()
+
+        service.handleActivityChange(true)
+        service.handleActivityChange(false)
+        service.handleActivityChange(true)
+
+        #expect(notifier.postedCount == 2)
+    }
+
+    @Test("cooldown suppresses a second notification within the window")
+    func testCooldownSuppressesSecondNotification() {
+        let (service, _, notifier, _) = makeService(enabled: true, cooldown: 5 * 60)
+        service.start()
+
+        service.handleActivityChange(true)
+        service.handleActivityChange(false)
+        service.handleActivityChange(true)  // within cooldown
+
+        #expect(notifier.postedCount == 1)
+    }
+
+    @Test("disabled setting suppresses notification on rising edge")
+    func testDisabledSuppressesNotification() {
+        let (service, _, notifier, settings) = makeService(enabled: true)
+        service.start()
+        settings.meetingDetectionEnabled = false
+
+        service.handleActivityChange(true)
+
+        #expect(notifier.postedCount == 0)
+    }
+
+    @Test("self microphone usage suppresses notification")
+    func testSelfUsageSuppressesNotification() {
+        let (service, _, notifier, _) = makeService(enabled: true)
+        service.isSelfUsingMicrophone = { true }
+        service.start()
+
+        service.handleActivityChange(true)
+
+        #expect(notifier.postedCount == 0)
+    }
+
+    @Test("stop() stops the monitor")
+    func testStopStopsMonitor() {
+        let (service, monitor, _, _) = makeService(enabled: true)
+        service.start()
+
+        service.stop()
+
+        #expect(monitor.isStarted == false)
+        #expect(monitor.stopCount == 1)
+    }
+}

--- a/wisprTests/SettingsStoreTests.swift
+++ b/wisprTests/SettingsStoreTests.swift
@@ -278,6 +278,26 @@ struct SettingsStoreTests {
         #expect(newStore.soundFeedbackEnabled == true, "soundFeedbackEnabled should persist")
     }
 
+    // MARK: - Meeting Detection Tests
+
+    @Test("SettingsStore meetingDetectionEnabled defaults to true")
+    func testMeetingDetectionDefault() {
+        let defaults = createTestDefaults()
+        let store = SettingsStore(defaults: defaults)
+        #expect(store.meetingDetectionEnabled == true)
+    }
+
+    @Test("SettingsStore persists meetingDetectionEnabled")
+    func testMeetingDetectionPersistence() {
+        let defaults = createTestDefaults()
+        let store = SettingsStore(defaults: defaults)
+        store.meetingDetectionEnabled = false
+
+        let newStore = SettingsStore(defaults: defaults)
+        #expect(
+            newStore.meetingDetectionEnabled == false, "meetingDetectionEnabled should persist")
+    }
+
     // MARK: - Filler Word Removal Tests
 
     @Test("SettingsStore removeFillerWords defaults to false")


### PR DESCRIPTION
Closes #70

Watches the default audio input device via CoreAudio (`kAudioDevicePropertyDeviceIsRunningSomewhere`). When another app starts using the microphone, posts an actionable notification to start meeting transcription in one click.

- **Opt-in**: disabled by default, toggle in Settings (existing users' UX is unchanged).
- Rising-edge only, cooldown, ignores Wispr's own mic use; start-time and device-change emissions only seed state (never a false edge).
- Fully local, no extra entitlement or Info.plist string.
- Concurrency: `AudioInputActivityMonitor` is a Swift 6 `actor`; the notifier uses async `UNUserNotificationCenter` APIs and awaits authorization before arming.
- Unit-tested coordinator (fake monitor + notifier), including baseline-suppression cases.
