### PR TITLE
Fix model download progress freezing at 52%

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "cdd624f9fef60efd23c1e90230b79cee2f8da18ff20e5f46641fbab24737f30f",
+  "originHash" : "161f968ac10d5a11379034e560e46695349ae8d22f0f6792e9051db66b9e83a8",
   "pins" : [
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "d9eef864d29783fc22754b12090631da5388c3a9",
-        "version" : "0.13.4"
+        "revision" : "19600a485baa4998812e4654b70d2bab8f2c9949",
+        "version" : "0.15.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/argmaxinc/WhisperKit.git", exact: "0.17.0"),
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", exact: "0.13.4"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", exact: "0.15.5"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
     ],
     targets: [

--- a/Sources/WisprApp/UI/ModelDownloadProgressView.swift
+++ b/Sources/WisprApp/UI/ModelDownloadProgressView.swift
@@ -161,16 +161,24 @@ struct ModelDownloadProgressView: View {
     // MARK: - Loading Model
 
     private var loadingModelView: some View {
-        VStack(spacing: 12) {
-            HStack(spacing: 10) {
-                ProgressView()
-                    .controlSize(.small)
+        VStack(spacing: 10) {
+            HStack {
                 Text("Preparing \(model.displayName)…")
                     .font(.headline)
                     .foregroundStyle(theme.primaryTextColor)
+                Spacer()
+                Text("\(Int(progress * 100))%")
+                    .font(.headline)
+                    .monospacedDigit()
+                    .foregroundStyle(theme.accentColor)
             }
 
-            Text("Loading model into memory. This may take a moment for larger models.")
+            GradientProgressBar(progress: progress, accentColor: theme.accentColor)
+                .animation(.easeInOut(duration: 0.3), value: progress)
+                .accessibilityLabel("Preparation progress")
+                .accessibilityValue("\(Int(progress * 100)) percent")
+
+            Text("Compiling model for the Neural Engine. This may take a moment for larger models.")
                 .font(.callout)
                 .foregroundStyle(theme.secondaryTextColor)
                 .multilineTextAlignment(.center)
@@ -178,7 +186,7 @@ struct ModelDownloadProgressView: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Preparing \(model.displayName). Loading model into memory.")
+        .accessibilityLabel("Preparing \(model.displayName). Compiling model for the Neural Engine.")
     }
 
     // MARK: - Warming Up
@@ -275,6 +283,12 @@ struct ModelDownloadProgressView: View {
                         downloadedBytes = downloadProgress.bytesDownloaded
                         totalBytes = downloadProgress.totalBytes
                     case .loadingModel:
+                        if downloadProgress.fractionCompleted != progress {
+                            lastProgressUpdate = .now
+                        }
+                        progress = downloadProgress.fractionCompleted
+                        downloadedBytes = downloadProgress.bytesDownloaded
+                        totalBytes = downloadProgress.totalBytes
                         isDownloading = false
                         isLoadingModel = true
                         isWarmingUp = false

--- a/Sources/WisprApp/UI/ModelDownloadProgressView.swift
+++ b/Sources/WisprApp/UI/ModelDownloadProgressView.swift
@@ -161,24 +161,16 @@ struct ModelDownloadProgressView: View {
     // MARK: - Loading Model
 
     private var loadingModelView: some View {
-        VStack(spacing: 10) {
-            HStack {
+        VStack(spacing: 12) {
+            HStack(spacing: 10) {
+                ProgressView()
+                    .controlSize(.small)
                 Text("Preparing \(model.displayName)…")
                     .font(.headline)
                     .foregroundStyle(theme.primaryTextColor)
-                Spacer()
-                Text("\(Int(progress * 100))%")
-                    .font(.headline)
-                    .monospacedDigit()
-                    .foregroundStyle(theme.accentColor)
             }
 
-            GradientProgressBar(progress: progress, accentColor: theme.accentColor)
-                .animation(.easeInOut(duration: 0.3), value: progress)
-                .accessibilityLabel("Preparation progress")
-                .accessibilityValue("\(Int(progress * 100)) percent")
-
-            Text("Compiling model for the Neural Engine. This may take a moment for larger models.")
+            Text("Compiling the model for the Neural Engine. This can take a couple of minutes for larger models.")
                 .font(.callout)
                 .foregroundStyle(theme.secondaryTextColor)
                 .multilineTextAlignment(.center)
@@ -186,7 +178,7 @@ struct ModelDownloadProgressView: View {
         .frame(maxWidth: .infinity)
         .padding(.vertical, 8)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Preparing \(model.displayName). Compiling model for the Neural Engine.")
+        .accessibilityLabel("Preparing \(model.displayName). Compiling the model for the Neural Engine. This can take a couple of minutes.")
     }
 
     // MARK: - Warming Up
@@ -283,12 +275,6 @@ struct ModelDownloadProgressView: View {
                         downloadedBytes = downloadProgress.bytesDownloaded
                         totalBytes = downloadProgress.totalBytes
                     case .loadingModel:
-                        if downloadProgress.fractionCompleted != progress {
-                            lastProgressUpdate = .now
-                        }
-                        progress = downloadProgress.fractionCompleted
-                        downloadedBytes = downloadProgress.bytesDownloaded
-                        totalBytes = downloadProgress.totalBytes
                         isDownloading = false
                         isLoadingModel = true
                         isWarmingUp = false

--- a/Sources/WisprApp/UI/ModelManagementView.swift
+++ b/Sources/WisprApp/UI/ModelManagementView.swift
@@ -101,7 +101,7 @@ struct ModelManagementView: View {
             groups[model.provider, default: []].append(model)
         }
         var items: [ModelListItem] = []
-        for provider in seen {
+        for provider in seen.sorted(by: { $0.rawValue < $1.rawValue }) {
             items.append(.header(provider))
             for model in groups[provider, default: []] {
                 items.append(.model(model))

--- a/Sources/WisprCore/Services/ParakeetService.swift
+++ b/Sources/WisprCore/Services/ParakeetService.swift
@@ -64,9 +64,13 @@ public actor ParakeetService {
 
     // MARK: - V3 Helpers
 
-    private func downloadAndLoad() async throws {
+    private func downloadAndLoad(progressHandler: DownloadUtils.ProgressHandler? = nil) async throws {
         let sdkLeaf = AsrModels.defaultCacheDirectory(for: .v3).lastPathComponent
-        let models = try await AsrModels.downloadAndLoad(to: ModelPaths.parakeetV3(sdkLeafName: sdkLeaf), version: .v3)
+        let models = try await AsrModels.downloadAndLoad(
+            to: ModelPaths.parakeetV3(sdkLeafName: sdkLeaf),
+            version: .v3,
+            progressHandler: progressHandler
+        )
         let manager = AsrManager(config: .default)
         try await manager.initialize(models: models)
         self.asrManager = manager
@@ -84,13 +88,17 @@ public actor ParakeetService {
     // MARK: - EOU Helpers
 
 
-    private func downloadAndLoadEou() async throws {
+    private func downloadAndLoadEou(progressHandler: DownloadUtils.ProgressHandler? = nil) async throws {
         let cacheDir = ModelPaths.parakeetEou
         let cachedFileCount = countFiles(in: cacheDir)
 
         // Only download if the cache is incomplete
         if cachedFileCount < Self.eouExpectedFileCount {
-            try await DownloadUtils.downloadRepo(.parakeetEou160, to: ModelPaths.parakeetEouParent)
+            try await DownloadUtils.downloadRepo(
+                .parakeetEou160,
+                to: ModelPaths.parakeetEouParent,
+                progressHandler: progressHandler
+            )
         }
         let config = MLModelConfiguration()
         config.computeUnits = .cpuAndNeuralEngine
@@ -233,14 +241,6 @@ extension ParakeetService: TranscriptionEngine {
 
         let isEou = model.id == ModelInfo.KnownID.parakeetEou
         let estimatedSize = model.estimatedSize
-        let expectedFileCount = isEou ? Self.eouExpectedFileCount : Self.expectedFileCount
-        let cacheDir: URL
-        if isEou {
-            cacheDir = ModelPaths.parakeetEou
-        } else {
-            let sdkLeaf = AsrModels.defaultCacheDirectory(for: .v3).lastPathComponent
-            cacheDir = ModelPaths.parakeetV3(sdkLeafName: sdkLeaf)
-        }
 
         let task = Task {
             defer { self.downloadTasks.removeValue(forKey: model.id) }
@@ -253,36 +253,33 @@ extension ParakeetService: TranscriptionEngine {
                     totalBytes: estimatedSize
                 ))
 
-                // Poll cache directory for file-count progress during download
-                let progressTask = Task {
-                    while !Task.isCancelled {
-                        try await Task.sleep(for: .milliseconds(500))
-                        let count = countFiles(in: cacheDir)
-                        if count >= expectedFileCount {
-                            continuation.yield(DownloadProgress(
-                                phase: .loadingModel,
-                                fractionCompleted: 1.0,
-                                bytesDownloaded: estimatedSize,
-                                totalBytes: estimatedSize
-                            ))
-                            break
-                        }
-                        let fraction = Double(count) / Double(expectedFileCount)
-                        let downloaded = Int64(Double(estimatedSize) * fraction)
-                        continuation.yield(DownloadProgress(
-                            phase: .downloading,
-                            fractionCompleted: fraction,
-                            bytesDownloaded: downloaded,
-                            totalBytes: estimatedSize
-                        ))
+                // Forward FluidAudio's real byte-level progress. It reports
+                // 0.0–0.5 while downloading files and 0.5–1.0 while compiling
+                // the CoreML models, so a single large file no longer freezes
+                // the bar at a fixed percentage.
+                let progressHandler: DownloadUtils.ProgressHandler = { faProgress in
+                    let phase: DownloadProgress.Phase
+                    switch faProgress.phase {
+                    case .compiling:
+                        phase = .loadingModel
+                    case .listing, .downloading:
+                        phase = .downloading
+                    @unknown default:
+                        phase = .downloading
                     }
+                    let fraction = faProgress.fractionCompleted
+                    continuation.yield(DownloadProgress(
+                        phase: phase,
+                        fractionCompleted: fraction,
+                        bytesDownloaded: Int64(Double(estimatedSize) * fraction),
+                        totalBytes: estimatedSize
+                    ))
                 }
-                defer { progressTask.cancel() }
 
                 if isEou {
-                    try await self.downloadAndLoadEou()
+                    try await self.downloadAndLoadEou(progressHandler: progressHandler)
                 } else {
-                    try await self.downloadAndLoad()
+                    try await self.downloadAndLoad(progressHandler: progressHandler)
                 }
                 self.activeModelName = model.id
 

--- a/Sources/WisprCore/Services/ParakeetService.swift
+++ b/Sources/WisprCore/Services/ParakeetService.swift
@@ -64,7 +64,7 @@ public actor ParakeetService {
 
     // MARK: - V3 Helpers
 
-    private func downloadAndLoad(progressHandler: DownloadUtils.ProgressHandler? = nil) async throws {
+    private func downloadAndLoad(progressHandler: ProgressHandler? = nil) async throws {
         let sdkLeaf = AsrModels.defaultCacheDirectory(for: .v3).lastPathComponent
         let models = try await AsrModels.downloadAndLoad(
             to: ModelPaths.parakeetV3(sdkLeafName: sdkLeaf),
@@ -72,7 +72,7 @@ public actor ParakeetService {
             progressHandler: progressHandler
         )
         let manager = AsrManager(config: .default)
-        try await manager.initialize(models: models)
+        try await manager.loadModels(models)
         self.asrManager = manager
         self.isDownloaded = true
         Log.whisperService.debug("ParakeetService — V3 downloadAndLoad completed")
@@ -88,13 +88,13 @@ public actor ParakeetService {
     // MARK: - EOU Helpers
 
 
-    private func downloadAndLoadEou(progressHandler: DownloadUtils.ProgressHandler? = nil) async throws {
+    private func downloadAndLoadEou(progressHandler: ProgressHandler? = nil) async throws {
         let cacheDir = ModelPaths.parakeetEou
         let cachedFileCount = countFiles(in: cacheDir)
 
         // Only download if the cache is incomplete
         if cachedFileCount < Self.eouExpectedFileCount {
-            try await DownloadUtils.downloadRepo(
+            try await ModelHub.download(
                 .parakeetEou160,
                 to: ModelPaths.parakeetEouParent,
                 progressHandler: progressHandler
@@ -107,7 +107,7 @@ public actor ParakeetService {
             chunkSize: .ms160,
             eouDebounceMs: 800 // ms of silence before generating an end of utterance
         )
-        try await manager.loadModels(modelDir: cacheDir)
+        try await manager.loadModels(from: cacheDir)
         self.eouManager = manager
         self.isEouDownloaded = true
         Log.whisperService.debug("ParakeetService — EOU downloadAndLoad completed")
@@ -253,27 +253,31 @@ extension ParakeetService: TranscriptionEngine {
                     totalBytes: estimatedSize
                 ))
 
-                // Forward FluidAudio's real byte-level progress. It reports
-                // 0.0–0.5 while downloading files and 0.5–1.0 while compiling
-                // the CoreML models, so a single large file no longer freezes
-                // the bar at a fixed percentage.
-                let progressHandler: DownloadUtils.ProgressHandler = { faProgress in
-                    let phase: DownloadProgress.Phase
+                // Forward FluidAudio's byte-level progress. It reports 0.0–0.5
+                // while downloading files and 0.5–1.0 while compiling the CoreML
+                // models. The download half is rescaled to a full 0–1 bar; the
+                // compile half is surfaced as an indeterminate preparation phase.
+                let progressHandler: ProgressHandler = { faProgress in
                     switch faProgress.phase {
                     case .compiling:
-                        phase = .loadingModel
+                        continuation.yield(DownloadProgress(
+                            phase: .loadingModel,
+                            fractionCompleted: 1.0,
+                            bytesDownloaded: estimatedSize,
+                            totalBytes: estimatedSize
+                        ))
                     case .listing, .downloading:
-                        phase = .downloading
+                        // FluidAudio caps download at 0.5; rescale to a full bar.
+                        let downloadFraction = min(faProgress.fractionCompleted * 2.0, 1.0)
+                        continuation.yield(DownloadProgress(
+                            phase: .downloading,
+                            fractionCompleted: downloadFraction,
+                            bytesDownloaded: Int64(Double(estimatedSize) * downloadFraction),
+                            totalBytes: estimatedSize
+                        ))
                     @unknown default:
-                        phase = .downloading
+                        break
                     }
-                    let fraction = faProgress.fractionCompleted
-                    continuation.yield(DownloadProgress(
-                        phase: phase,
-                        fractionCompleted: fraction,
-                        bytesDownloaded: Int64(Double(estimatedSize) * fraction),
-                        totalBytes: estimatedSize
-                    ))
                 }
 
                 if isEou {
@@ -478,7 +482,8 @@ extension ParakeetService: TranscriptionEngine {
         }
 
         let startTime = Date()
-        let result = try await asrManager.transcribe(audioSamples, source: .microphone)
+        var decoderState = try TdtDecoderState()
+        let result = try await asrManager.transcribe(audioSamples, decoderState: &decoderState)
 
         let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else {

--- a/wispr.xcodeproj/project.pbxproj
+++ b/wispr.xcodeproj/project.pbxproj
@@ -1329,8 +1329,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/FluidInference/FluidAudio.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.12.1;
+				kind = exactVersion;
+				version = 0.15.5;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/wispr.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/wispr.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "6448c4cff3a6be06bb8cfeab56abda72744a0395416a857478ac54fad7f8f558",
+  "originHash" : "105d45af75ba3334751e7ccbd27cbb3936f8c97fcc7fd2afd220773c9bb7776d",
   "pins" : [
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "d9eef864d29783fc22754b12090631da5388c3a9",
-        "version" : "0.13.4"
+        "revision" : "19600a485baa4998812e4654b70d2bab8f2c9949",
+        "version" : "0.15.5"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "626b5b7b2f45e1b0b1c6f4a309296d1d21d7311b",
-        "version" : "1.7.1"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
-        "version" : "1.6.0"
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
-        "version" : "1.4.1"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "fa308c07a6fa04a727212d793e761460e41049c3",
-        "version" : "4.3.0"
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
-        "version" : "2.3.5"
+        "revision" : "9cde95abb5a01c6428137a5f9b50a2b994b53c25",
+        "version" : "2.4.1"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/argmaxinc/WhisperKit.git",
       "state" : {
-        "revision" : "26577ce3017aae8c9edfd9a0dd17851bd248c731",
-        "version" : "0.17.0"
+        "revision" : "e2adabbe7d98dc4d0ab9a5b75424ecc42a9cdbef",
+        "version" : "0.18.0"
       }
     },
     {


### PR DESCRIPTION
## Summary
Onboarding's model download progress bar consistently froze — first reported at **52%** for 1-2 minutes, reproducible across machines, days, and networks. A deterministic freeze point ruled out a networking cause.

## Root cause (two layers)
1. **Fake progress:** `ParakeetService.downloadModel` faked progress by polling the cache directory and reporting `fileCount / 23`. The Encoder weights file is ~445 MB (92% of the download) but counts as 1 of 23 files → `12/23 ≈ 52%` froze while that single file streamed.
2. **The real blocker:** switching to FluidAudio's byte-level `progressHandler` only moved the freeze (to ~2%, then a jump to ~39%). Instrumented logs proved FluidAudio **0.13.4**'s downloader combined async `URLSession.download(for:)` with a `URLSessionDownloadDelegate` — a pairing that never delivers `didWriteData`. Only per-*file-completion* callbacks fired, so the 445 MB Encoder produced zero progress for minutes.

## Fix: upgrade FluidAudio 0.13.4 → 0.15.5
FluidAudio 0.15.x rewrote the downloader (`FileDownloader.streamDownload` uses `dataTask` + a continuation-driven streaming delegate), so per-byte progress fires correctly. **Verified:** a fresh download now shows continuous byte-level movement through the large Encoder file.

### API migration required by the upgrade
- `DownloadUtils.downloadRepo` → `ModelHub.download`
- `DownloadUtils.ProgressHandler` → `ProgressHandler` (now top-level)
- `AsrManager.initialize(models:)` → `loadModels(_:)`
- `StreamingEouAsrManager.loadModels(modelDir:)` → `loadModels(from:)`
- `AsrManager.transcribe(_:source:)` → `transcribe(_:decoderState:)` — batch transcription uses a fresh `TdtDecoderState` per call (equivalent to the old stateless call). Echo suppression is text-level and unaffected; Sortformer diarization API is unchanged.

## Progress UX
- Download half (FluidAudio 0.0-0.5) rescaled to a full 0-1 bar, byte-accurate.
- Compile half surfaced as an indeterminate "Preparing" spinner with a "can take a couple of minutes" message (no fake percentage during CoreML compilation).

## Also included
- Sort providers alphabetically in Model Management so **NVIDIA Parakeet** lists before **OpenAI Whisper**.

## Testing
- `xcodebuild -scheme wispr -configuration Debug build` → **BUILD SUCCEEDED**
- Manually verified fresh Parakeet V3 download: byte-level progress advances continuously through the 445 MB Encoder file (previously frozen). Logs confirmed the cadence.
- Note: `xcodebuild test` currently fails to compile due to a **pre-existing, unrelated** error in `TranscriptStoreTests.swift` (`others(speakerIndex:)`, from the meeting-diarizer work) — confirmed present with these changes stashed.
- Recommended before merge: a quick transcription smoke test, since the `transcribe` API changed the most.

Fixes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)