### PR TITLE
Add custom vocabulary correction for proper nouns and tool names

### DIFF
--- a/Sources/WisprApp/Services/MeetingStateManager.swift
+++ b/Sources/WisprApp/Services/MeetingStateManager.swift
@@ -203,6 +203,20 @@ final class MeetingStateManager {
 
     // MARK: - Transcription
 
+    /// Corrects mis-transcribed proper nouns against the user's custom vocabulary
+    /// when the setting is enabled. Mirrors `StateManager.applyVocabularyCorrection`:
+    /// uses the configured language, falling back to the detected one in auto-detect.
+    private func applyVocabularyCorrection(to text: String, detectedLanguage: String?) -> String {
+        guard settingsStore.customVocabularyEnabled,
+              !settingsStore.customVocabulary.isEmpty,
+              !text.isEmpty else { return text }
+        return VocabularyCorrector.correct(
+            text,
+            vocabulary: settingsStore.customVocabulary,
+            languageCode: settingsStore.languageMode.languageCode ?? detectedLanguage
+        )
+    }
+
     private func transcribeMicAudio() async {
         let audioStream = await meetingAudioEngine.micAudioStream
         let language = settingsStore.languageMode
@@ -213,8 +227,9 @@ final class MeetingStateManager {
 
             do {
                 let result = try await transcriptionEngine.transcribe(chunk, language: language)
-                let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                var text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !text.isEmpty else { continue }
+                text = applyVocabularyCorrection(to: text, detectedLanguage: result.detectedLanguage)
 
                 record(MeetingTranscriptEntry(speaker: .you, text: text))
             } catch {
@@ -243,8 +258,9 @@ final class MeetingStateManager {
             do {
                 let result = try await transcriptionEngine.transcribe(
                     audioChunk.samples, language: language)
-                let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                var text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !text.isEmpty else { continue }
+                text = applyVocabularyCorrection(to: text, detectedLanguage: result.detectedLanguage)
 
                 // Resolve the dominant speaker over the chunk's time window.
                 // nil (cold-start or diarization disabled) renders as "Others".

--- a/Sources/WisprApp/Services/SettingsStore.swift
+++ b/Sources/WisprApp/Services/SettingsStore.swift
@@ -182,6 +182,28 @@ final class SettingsStore {
         }
     }
 
+    // MARK: - Custom Vocabulary Settings
+
+    /// When true, transcriptions are corrected against `customVocabulary` so
+    /// mis-transcribed proper nouns (client names, etc.) are fixed to their
+    /// canonical spelling.
+    var customVocabularyEnabled: Bool {
+        didSet {
+            guard !isLoading else { return }
+            defaults.set(customVocabularyEnabled, forKey: Keys.customVocabularyEnabled)
+        }
+    }
+
+    /// Correctly spelled words the transcription is biased toward (e.g. "kubectl").
+    var customVocabulary: [String] {
+        didSet {
+            guard !isLoading else { return }
+            if let encoded = try? JSONEncoder().encode(customVocabulary) {
+                defaults.set(encoded, forKey: Keys.customVocabulary)
+            }
+        }
+    }
+
     // MARK: - UserDefaults Keys
     private enum Keys {
         static let hotkeyKeyCode = "hotkeyKeyCode"
@@ -203,6 +225,8 @@ final class SettingsStore {
         static let autoSendEnterEnabled = "autoSendEnterEnabled"
         static let aiTextCorrectionEnabled = "aiTextCorrectionEnabled"
         static let aiTextCorrectionStyle = "aiTextCorrectionStyle"
+        static let customVocabularyEnabled = "customVocabularyEnabled"
+        static let customVocabulary = "customVocabulary"
     }
 
     // MARK: - Default Values
@@ -229,6 +253,8 @@ final class SettingsStore {
         static let autoSendEnterEnabled: Bool = false
         static let aiTextCorrectionEnabled: Bool = false
         static let aiTextCorrectionStyle: CorrectionStyle = .minimal
+        static let customVocabularyEnabled: Bool = false
+        static let customVocabulary: [String] = []
     }
 
     // MARK: - Dependencies
@@ -259,6 +285,8 @@ final class SettingsStore {
         self.autoSendEnterEnabled = Defaults.autoSendEnterEnabled
         self.aiTextCorrectionEnabled = Defaults.aiTextCorrectionEnabled
         self.aiTextCorrectionStyle = Defaults.aiTextCorrectionStyle
+        self.customVocabularyEnabled = Defaults.customVocabularyEnabled
+        self.customVocabulary = Defaults.customVocabulary
 
         // Load persisted values
         load()
@@ -287,6 +315,8 @@ final class SettingsStore {
         autoSendEnterEnabled = Defaults.autoSendEnterEnabled
         aiTextCorrectionEnabled = Defaults.aiTextCorrectionEnabled
         aiTextCorrectionStyle = Defaults.aiTextCorrectionStyle
+        customVocabularyEnabled = Defaults.customVocabularyEnabled
+        customVocabulary = Defaults.customVocabulary
     }
 
     // MARK: - Persistence
@@ -313,6 +343,7 @@ final class SettingsStore {
         defaults.set(removeFillerWords, forKey: Keys.removeFillerWords)
         defaults.set(autoSendEnterEnabled, forKey: Keys.autoSendEnterEnabled)
         defaults.set(aiTextCorrectionEnabled, forKey: Keys.aiTextCorrectionEnabled)
+        defaults.set(customVocabularyEnabled, forKey: Keys.customVocabularyEnabled)
 
         if let encoded = try? JSONEncoder().encode(languageMode) {
             defaults.set(encoded, forKey: Keys.languageMode)
@@ -320,6 +351,10 @@ final class SettingsStore {
 
         if let encoded = try? JSONEncoder().encode(aiTextCorrectionStyle) {
             defaults.set(encoded, forKey: Keys.aiTextCorrectionStyle)
+        }
+
+        if let encoded = try? JSONEncoder().encode(customVocabulary) {
+            defaults.set(encoded, forKey: Keys.customVocabulary)
         }
     }
 
@@ -415,6 +450,17 @@ final class SettingsStore {
             let decoded = try? JSONDecoder().decode(CorrectionStyle.self, from: data)
         {
             self.aiTextCorrectionStyle = decoded
+        }
+
+        // Load custom vocabulary settings
+        if defaults.object(forKey: Keys.customVocabularyEnabled) != nil {
+            self.customVocabularyEnabled = defaults.bool(forKey: Keys.customVocabularyEnabled)
+        }
+
+        if let data = defaults.data(forKey: Keys.customVocabulary),
+            let decoded = try? JSONDecoder().decode([String].self, from: data)
+        {
+            self.customVocabulary = decoded
         }
     }
 

--- a/Sources/WisprApp/Services/StateManager.swift
+++ b/Sources/WisprApp/Services/StateManager.swift
@@ -252,6 +252,21 @@ final class StateManager {
         return FillerWordCleaner.clean(text)
     }
 
+    // MARK: - Custom Vocabulary Correction
+
+    /// Corrects mis-transcribed proper nouns against the user's custom vocabulary
+    /// when the setting is enabled and the list is non-empty.
+    func applyVocabularyCorrection(to text: String) -> String {
+        guard settingsStore.customVocabularyEnabled,
+              !settingsStore.customVocabulary.isEmpty,
+              !text.isEmpty else { return text }
+        return VocabularyCorrector.correct(
+            text,
+            vocabulary: settingsStore.customVocabulary,
+            languageCode: settingsStore.languageMode.languageCode
+        )
+    }
+
     // MARK: - AI Text Correction
 
     /// Applies AI text correction if enabled and available.
@@ -321,7 +336,11 @@ final class StateManager {
         // AI text correction step (after filler removal, before suffix)
         let corrected = await applyAITextCorrection(to: cleaned)
 
-        let finalText = applyAutoSuffix(to: corrected)
+        // Custom vocabulary correction — runs after AI correction so it has the
+        // final say on the spelling of known proper nouns.
+        let vocabCorrected = applyVocabularyCorrection(to: corrected)
+
+        let finalText = applyAutoSuffix(to: vocabCorrected)
 
         do {
             try await textInsertionService.insertText(finalText)

--- a/Sources/WisprApp/Services/StateManager.swift
+++ b/Sources/WisprApp/Services/StateManager.swift
@@ -230,7 +230,8 @@ final class StateManager {
 
                 self.soundFeedback.play(.recordingStopped)
 
-                await self.insertTranscribedText(finalResult.text)
+                await self.insertTranscribedText(
+                    finalResult.text, detectedLanguage: finalResult.detectedLanguage)
             } catch {
                 guard !Task.isCancelled else { return }
                 Log.stateManager.warning("EOU monitoring failed: \(error.localizedDescription)")
@@ -256,14 +257,18 @@ final class StateManager {
 
     /// Corrects mis-transcribed proper nouns against the user's custom vocabulary
     /// when the setting is enabled and the list is non-empty.
-    func applyVocabularyCorrection(to text: String) -> String {
+    ///
+    /// The language used for phonetic matching is the configured one when pinned
+    /// or specific; in auto-detect mode (where `languageMode.languageCode` is nil)
+    /// it falls back to the language the engine detected for this transcription.
+    func applyVocabularyCorrection(to text: String, detectedLanguage: String? = nil) -> String {
         guard settingsStore.customVocabularyEnabled,
               !settingsStore.customVocabulary.isEmpty,
               !text.isEmpty else { return text }
         return VocabularyCorrector.correct(
             text,
             vocabulary: settingsStore.customVocabulary,
-            languageCode: settingsStore.languageMode.languageCode
+            languageCode: settingsStore.languageMode.languageCode ?? detectedLanguage
         )
     }
 
@@ -319,7 +324,7 @@ final class StateManager {
     /// Called by both `endRecording()` and the EOU handler to avoid duplication.
     ///
     /// **Validates**: Requirements 3.1, 3.2, 3.3, 3.4, 4.1, 4.3, 4.4, 5.6, 5.7, 5.9
-    func insertTranscribedText(_ text: String) async {
+    func insertTranscribedText(_ text: String, detectedLanguage: String? = nil) async {
         guard !text.isEmpty else {
             await resetToIdle()
             return
@@ -338,7 +343,7 @@ final class StateManager {
 
         // Custom vocabulary correction — runs after AI correction so it has the
         // final say on the spelling of known proper nouns.
-        let vocabCorrected = applyVocabularyCorrection(to: corrected)
+        let vocabCorrected = applyVocabularyCorrection(to: corrected, detectedLanguage: detectedLanguage)
 
         let finalText = applyAutoSuffix(to: vocabCorrected)
 
@@ -530,7 +535,7 @@ final class StateManager {
             Log.stateManager.debug("endRecording — transcription: \"\(preview, privacy: .private)\" (len=\(result.text.count))")
             #endif
 
-            await insertTranscribedText(result.text)
+            await insertTranscribedText(result.text, detectedLanguage: result.detectedLanguage)
 
         } catch WisprError.emptyTranscription {
             // Requirement 3.4: Empty transcription — notify user and return to idle

--- a/Sources/WisprApp/UI/Components/VocabularyEditorView.swift
+++ b/Sources/WisprApp/UI/Components/VocabularyEditorView.swift
@@ -1,0 +1,79 @@
+//
+//  VocabularyEditorView.swift
+//  wispr
+//
+//  A compact editor for the custom vocabulary list: correctly spelled proper
+//  nouns (client names, product names) that transcription should be biased
+//  toward. Supports adding a new word and removing existing ones.
+//
+
+import SwiftUI
+
+/// Editor for the custom vocabulary word list bound to `SettingsStore.customVocabulary`.
+struct VocabularyEditorView: View {
+    @Binding var vocabulary: [String]
+    @State private var newWord = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Add-a-word row.
+            HStack(spacing: 6) {
+                TextField("Add a word (e.g. kubectl)", text: $newWord)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit(addWord)
+                    .accessibilityLabel("New vocabulary word")
+
+                Button(action: addWord) {
+                    Image(systemName: SFSymbols.addCircle)
+                }
+                .buttonStyle(.borderless)
+                .disabled(trimmedNewWord.isEmpty)
+                .accessibilityLabel("Add word")
+            }
+
+            // Existing words.
+            if vocabulary.isEmpty {
+                Text("No words yet. Add client or product names that are often mis-transcribed.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                ForEach(Array(vocabulary.enumerated()), id: \.offset) { index, word in
+                    HStack {
+                        Text(word)
+                        Spacer()
+                        Button {
+                            remove(at: index)
+                        } label: {
+                            Image(systemName: SFSymbols.removeCircle)
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.borderless)
+                        .accessibilityLabel("Remove \(word)")
+                    }
+                }
+            }
+        }
+    }
+
+    private var trimmedNewWord: String {
+        newWord.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Adds the typed word if it is non-empty and not already present
+    /// (case-insensitive), then clears the field.
+    private func addWord() {
+        let word = trimmedNewWord
+        guard !word.isEmpty else { return }
+        guard !vocabulary.contains(where: { $0.caseInsensitiveCompare(word) == .orderedSame }) else {
+            newWord = ""
+            return
+        }
+        vocabulary.append(word)
+        newWord = ""
+    }
+
+    private func remove(at index: Int) {
+        guard vocabulary.indices.contains(index) else { return }
+        vocabulary.remove(at: index)
+    }
+}

--- a/Sources/WisprApp/UI/Settings/SettingsView.swift
+++ b/Sources/WisprApp/UI/Settings/SettingsView.swift
@@ -63,6 +63,8 @@ struct SettingsView: View {
             "When enabled, uses on-device AI to correct grammar and improve transcription fluency. All processing stays on your Mac."
         static let autoInsertSuffix = "When enabled, appends a suffix to transcribed text"
         static let autoSendEnter = "When enabled, simulates pressing Enter after text insertion"
+        static let customVocabulary =
+            "When enabled, corrects mis-transcribed proper nouns like client names to the spelling you provide"
 
         // Feedback section
         static let soundFeedback = "When enabled, plays audio cues when recording starts and stops"
@@ -336,6 +338,13 @@ struct SettingsView: View {
             //     }
             // }
 
+            Toggle("Custom Vocabulary", isOn: $store.customVocabularyEnabled)
+                .accessibilityHint(AccessibilityHints.customVocabulary)
+
+            if settingsStore.customVocabularyEnabled {
+                VocabularyEditorView(vocabulary: $store.customVocabulary)
+            }
+
             Toggle("Auto-Insert Suffix", isOn: $store.autoSuffixEnabled)
                 .accessibilityHint(AccessibilityHints.autoInsertSuffix)
 
@@ -356,6 +365,7 @@ struct SettingsView: View {
         }
         .motionRespectingAnimation(value: settingsStore.autoSuffixEnabled)
         .motionRespectingAnimation(value: settingsStore.aiTextCorrectionEnabled)
+        .motionRespectingAnimation(value: settingsStore.customVocabularyEnabled)
     }
 
     // MARK: - Feedback Section

--- a/Sources/WisprApp/Utilities/SFSymbols.swift
+++ b/Sources/WisprApp/Utilities/SFSymbols.swift
@@ -142,6 +142,12 @@ enum SFSymbols {
     /// Plain checkmark for active/completion states.
     static let checkmarkPlain = "checkmark"
 
+    /// Add / insert icon.
+    static let addCircle = "plus.circle.fill"
+
+    /// Remove item icon.
+    static let removeCircle = "minus.circle.fill"
+
     /// Arrow down for downloaded model indicator.
     static let arrowDown = "arrow.down"
 

--- a/Sources/WisprApp/Utilities/VocabularyCorrector.swift
+++ b/Sources/WisprApp/Utilities/VocabularyCorrector.swift
@@ -38,6 +38,13 @@ enum VocabularyCorrector {
     /// tokens ("data ecou"), so we must look at multi-word windows.
     private static let maxWindow = 3
 
+    /// Minimum phonetic-key length for fuzzy matching. On 1–2 character keys the
+    /// normalized edit distance is effectively binary, so the similarity threshold
+    /// cannot discriminate ("Go" → key "g" would match any word folding to "g").
+    /// Shorter keys only match when both keys are identical AND the original
+    /// words are equal case-insensitively.
+    private static let minKeyLengthForFuzzyMatch = 3
+
     /// A vocabulary entry paired with its phonetic key per candidate language.
     private struct Entry {
         let canonical: String
@@ -185,6 +192,14 @@ enum VocabularyCorrector {
             var entryScore = 0.0
             for language in languages {
                 guard let wk = windowKeys[language], let ek = entry.keysByLanguage[language] else { continue }
+                // Keys too short for the threshold to discriminate: only accept a
+                // case-insensitive spelling match (still fixes casing, e.g. "go" → "Go").
+                if ek.count < minKeyLengthForFuzzyMatch || wk.count < minKeyLengthForFuzzyMatch {
+                    if joined.caseInsensitiveCompare(entry.canonical) == .orderedSame {
+                        entryScore = 1
+                    }
+                    continue
+                }
                 entryScore = max(entryScore, similarity(wk, ek))
             }
             if entryScore >= similarityThreshold, entryScore > (best?.score ?? 0) {
@@ -346,7 +361,8 @@ enum VocabularyCorrector {
     // MARK: - Tokenization
 
     /// Splits text into non-whitespace tokens and the whitespace runs between
-    /// them, so `reassemble` can restore the exact original spacing.
+    /// them, so the rebuild in `correct(_:vocabulary:languageCode:)` can restore
+    /// the exact original spacing.
     private static func tokenize(_ text: String) -> (tokens: [String], separators: [String]) {
         var tokens: [String] = []
         var separators: [String] = []

--- a/Sources/WisprApp/Utilities/VocabularyCorrector.swift
+++ b/Sources/WisprApp/Utilities/VocabularyCorrector.swift
@@ -1,0 +1,406 @@
+//
+//  VocabularyCorrector.swift
+//  wispr
+//
+//  Corrects proper nouns / client names that the ASR model mis-transcribes by
+//  matching transcription tokens against a user-provided vocabulary.
+//
+//  The model often gets domain-specific proper nouns and tool names wrong
+//  ("kubectl" becomes "cube cuttle" or "cubectel"; "PyTorch" the wrong case).
+//  This utility scans the transcription for runs of 1–3 words whose *sound*
+//  matches a vocabulary entry and rewrites them to the canonical spelling.
+//
+//  Matching is engine-agnostic (runs on Whisper and Parakeet output alike) and
+//  purely lexical: a lightweight phonetic key plus a normalized edit-distance
+//  threshold. The threshold is deliberately high so that only genuine
+//  sound-alikes are replaced and ordinary words are left untouched.
+//
+//  A word may be pronounced differently depending on language — e.g. "PyTorch"
+//  said the French way ("pitorche") vs the English way ("païtorche") — and the
+//  model transcribes each phonetically. To cover this, every word is folded once
+//  per candidate language (the user's transcription language plus English, since
+//  tech proper nouns are usually English) and a match on ANY language wins.
+//  Both the transcription window and the vocabulary entry are folded with the
+//  SAME language rules before comparison, so the comparison stays consistent.
+//
+
+import Foundation
+
+enum VocabularyCorrector {
+
+    /// Minimum phonetic similarity (1 - normalized Levenshtein) required to
+    /// replace a window with a vocabulary entry. High to avoid false positives —
+    /// vocabulary entries are proper nouns, so we only want near-exact sound-alikes.
+    private static let similarityThreshold = 0.8
+
+    /// Largest number of consecutive transcription words considered as a single
+    /// candidate. The model frequently splits an unknown proper noun into several
+    /// tokens ("data ecou"), so we must look at multi-word windows.
+    private static let maxWindow = 3
+
+    /// A vocabulary entry paired with its phonetic key per candidate language.
+    private struct Entry {
+        let canonical: String
+        /// Folded key keyed by language pass (see `phoneticKeys(for:languages:)`).
+        let keysByLanguage: [String: String]
+    }
+
+    /// A potential replacement: a run of `len` tokens starting at `start` that
+    /// matches `canonical` with the given phonetic `score`.
+    private struct Candidate {
+        let start: Int
+        let len: Int
+        let canonical: String
+        let score: Double
+    }
+
+    /// Rewrites runs of words in `text` that phonetically match a `vocabulary`
+    /// entry to that entry's canonical spelling.
+    ///
+    /// - Parameters:
+    ///   - text: Raw transcription text.
+    ///   - vocabulary: Correctly spelled words to bias toward (e.g. client names).
+    ///   - languageCode: The user's transcription language (ISO code like "fr",
+    ///     "it"), or nil for auto-detect. Matching is attempted in this language
+    ///     and in English; a match on either wins.
+    /// - Returns: The text with matched runs replaced by their canonical spelling.
+    static func correct(_ text: String, vocabulary: [String], languageCode: String? = nil) -> String {
+        guard !text.isEmpty else { return text }
+
+        let languages = candidateLanguages(for: languageCode)
+
+        let entries: [Entry] = vocabulary.compactMap { raw in
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            let keys = phoneticKeys(for: trimmed, languages: languages)
+            guard !keys.isEmpty else { return nil }
+            return Entry(canonical: trimmed, keysByLanguage: keys)
+        }
+        guard !entries.isEmpty else { return text }
+
+        // Split into whitespace-separated tokens, remembering the exact separators
+        // so the reconstructed string preserves original spacing/newlines.
+        let (tokens, separators) = tokenize(text)
+        guard !tokens.isEmpty else { return text }
+
+        let chosen = selectReplacements(for: tokens, entries: entries, languages: languages)
+
+        // Rebuild the string inline, keyed by original token index, so the
+        // captured separators (spacing/newlines) always stay aligned even when a
+        // window collapses several tokens into one replacement.
+        // separators[0] is any leading whitespace; separators[i+1] follows tokens[i].
+        var out = separators.first ?? ""
+        var i = 0
+        while i < tokens.count {
+            var consumed = 1
+            var piece = tokens[i]
+
+            if let candidate = chosen[i] {
+                let window = Array(tokens[i..<(i + candidate.len)])
+                // Reattach the leading/trailing punctuation of the window so
+                // "kubectl." stays "kubectl." and "kubectl," stays "kubectl,".
+                let (leading, _) = affixes(of: window.first!)
+                let (_, trailing) = affixes(of: window.last!)
+                piece = leading + candidate.canonical + trailing
+                consumed = candidate.len
+            }
+
+            out += piece
+            // Append the separator that followed the LAST token of this window,
+            // discarding any separators consumed inside the collapsed window.
+            let sepIndex = i + consumed
+            if sepIndex < separators.count {
+                out += separators[sepIndex]
+            }
+            i += consumed
+        }
+
+        return out
+    }
+
+    // MARK: - Replacement Selection
+
+    /// Finds the best set of non-overlapping token runs to replace.
+    ///
+    /// Every window of 1…`maxWindow` tokens is scored against the vocabulary.
+    /// Candidates are then chosen greedily by descending score so a strong match
+    /// wins over a weaker overlapping one — e.g. "kubernetes" (exact) beats
+    /// "on kubernetes" (near), keeping the "on". Ties prefer the *shorter* window
+    /// so an innocent neighbouring word is never swallowed ("PyTorch qui" keeps
+    /// "qui" rather than absorbing it into the match).
+    ///
+    /// - Returns: A map from a token's start index to the winning candidate.
+    private static func selectReplacements(for tokens: [String], entries: [Entry], languages: [String]) -> [Int: Candidate] {
+        // 1. Collect every scoring window.
+        var candidates: [Candidate] = []
+        for start in 0..<tokens.count {
+            let maxLen = min(maxWindow, tokens.count - start)
+            for len in 1...maxLen {
+                let window = Array(tokens[start..<(start + len)])
+                guard let (canonical, score) = bestMatch(for: window, in: entries, languages: languages) else { continue }
+                candidates.append(Candidate(start: start, len: len, canonical: canonical, score: score))
+            }
+        }
+
+        // 2. Sort by score desc; tie → shorter window, then earlier position.
+        candidates.sort { a, b in
+            if a.score != b.score { return a.score > b.score }
+            if a.len != b.len { return a.len < b.len }
+            return a.start < b.start
+        }
+
+        // 3. Greedily accept non-overlapping candidates.
+        var taken = [Bool](repeating: false, count: tokens.count)
+        var chosen: [Int: Candidate] = [:]
+        for candidate in candidates {
+            let range = candidate.start..<(candidate.start + candidate.len)
+            if range.contains(where: { taken[$0] }) { continue }
+            range.forEach { taken[$0] = true }
+            chosen[candidate.start] = candidate
+        }
+        return chosen
+    }
+
+    // MARK: - Matching
+
+    /// Returns the best vocabulary match for a window of tokens along with its
+    /// similarity score, or nil if none clears the similarity threshold.
+    ///
+    /// For each candidate language, the window and the vocabulary entry are folded
+    /// with the same language rules and compared; the highest score across all
+    /// languages wins. This lets one vocabulary word match multiple pronunciations
+    /// (e.g. "PyTorch" said the French or English way).
+    private static func bestMatch(for window: [String], in entries: [Entry], languages: [String]) -> (canonical: String, score: Double)? {
+        // Join the alphanumeric cores of the window (drops punctuation and the
+        // spaces between split tokens): ["data", "ecou."] → "dataecou".
+        let joined = window.map { core(of: $0) }.joined()
+        guard !joined.isEmpty else { return nil }
+
+        // Precompute the window's key per language once.
+        let windowKeys = phoneticKeys(for: joined, languages: languages)
+        guard !windowKeys.isEmpty else { return nil }
+
+        var best: (canonical: String, score: Double)?
+        for entry in entries {
+            var entryScore = 0.0
+            for language in languages {
+                guard let wk = windowKeys[language], let ek = entry.keysByLanguage[language] else { continue }
+                entryScore = max(entryScore, similarity(wk, ek))
+            }
+            if entryScore >= similarityThreshold, entryScore > (best?.score ?? 0) {
+                best = (entry.canonical, entryScore)
+            }
+        }
+        return best
+    }
+
+    // MARK: - Languages
+
+    /// The languages to try when matching: the user's transcription language
+    /// (if known) plus English, deduplicated and order-preserving. English is
+    /// always included because most tech proper nouns are English and may be
+    /// pronounced the English way regardless of the dictation language.
+    private static func candidateLanguages(for languageCode: String?) -> [String] {
+        var languages: [String] = []
+        if let code = languageCode?.lowercased(), !code.isEmpty {
+            // Normalize e.g. "en-US" → "en".
+            languages.append(String(code.prefix(2)))
+        }
+        if !languages.contains("en") { languages.append("en") }
+        return languages
+    }
+
+    // MARK: - Phonetic Key
+
+    /// Computes the phonetic key of `word` for each candidate language.
+    /// - Returns: A map `language → key`, skipping languages that fold to empty.
+    private static func phoneticKeys(for word: String, languages: [String]) -> [String: String] {
+        var keys: [String: String] = [:]
+        for language in languages {
+            let key = phoneticKey(word, language: language)
+            if !key.isEmpty { keys[language] = key }
+        }
+        return keys
+    }
+
+    /// Collapses a word to a coarse phonetic key so different spellings of the
+    /// same sound converge. Heuristic — not a full phonemizer, but enough that
+    /// "novaria", "novarya" and "nova ria" map to nearby keys.
+    /// Language-specific pronunciation rules run first, then a common fold.
+    static func phoneticKey(_ word: String, language: String) -> String {
+        commonFold(languagePrefold(language, word))
+    }
+
+    /// Applies language-specific pronunciation rules before the common fold.
+    /// Extensible: add cases for other languages as needed. An unknown language
+    /// falls through to the common fold only (a safe, neutral default).
+    private static func languagePrefold(_ language: String, _ word: String) -> String {
+        var s = word.lowercased()
+        switch language {
+        case "fr":
+            s = s.replacingOccurrences(of: "ill", with: "y")   // French "-ille-" ≈ /j/
+        case "en":
+            s = s.replacingOccurrences(of: "y", with: "ai")    // "py", "my" → /aɪ/
+            s = s.replacingOccurrences(of: "igh", with: "ai")  // "light"
+            s = s.replacingOccurrences(of: "oa", with: "o")    // "board"
+        default:
+            break
+        }
+        return s
+    }
+
+    /// Language-neutral fold: strip diacritics, keep letters, collapse common
+    /// digraphs and single-letter sounds, dedupe doubled letters, drop a trailing
+    /// schwa-ish vowel that models often add or drop.
+    private static func commonFold(_ word: String) -> String {
+        // Lowercase and strip diacritics: "dataïkou" → "dataikou".
+        var s = word.folding(options: .diacriticInsensitive, locale: nil).lowercased()
+
+        // Keep letters only.
+        s = String(s.unicodeScalars.filter { CharacterSet.letters.contains($0) })
+        guard !s.isEmpty else { return "" }
+
+        // Digraph / sound-alike folding (order matters).
+        let digraphs: [(String, String)] = [
+            ("ph", "f"),
+            ("qu", "k"),
+            ("ck", "k"),
+            ("ch", "k"),
+            ("ou", "u"),
+            ("oo", "u"),
+            ("ee", "i"),
+            ("ea", "i"),
+            ("ai", "e"),
+            ("ei", "e"),
+            ("au", "o"),
+            ("eau", "o"),
+        ]
+        for (from, to) in digraphs {
+            s = s.replacingOccurrences(of: from, with: to)
+        }
+
+        // Single-letter sound folding: c/q/k → k, y → i, w → v, z → s.
+        var folded = ""
+        for ch in s {
+            switch ch {
+            case "c", "q": folded.append("k")
+            case "y": folded.append("i")
+            case "w": folded.append("v")
+            case "z": folded.append("s")
+            default: folded.append(ch)
+            }
+        }
+
+        // Collapse doubled letters: "datta" → "data".
+        var deduped = ""
+        var last: Character?
+        for ch in folded {
+            if ch != last { deduped.append(ch) }
+            last = ch
+        }
+
+        // Drop a trailing schwa-ish vowel that speakers/models often add or
+        // drop ("novaria" vs "novariou" → both end effectively the same).
+        while let lastChar = deduped.last, "aeiou".contains(lastChar), deduped.count > 1 {
+            deduped.removeLast()
+            break
+        }
+
+        return deduped
+    }
+
+    // MARK: - Similarity
+
+    /// Normalized similarity in [0, 1]: 1 - editDistance / maxLength.
+    private static func similarity(_ a: String, _ b: String) -> Double {
+        if a == b { return 1 }
+        let maxLen = max(a.count, b.count)
+        guard maxLen > 0 else { return 1 }
+        let dist = levenshtein(Array(a), Array(b))
+        return 1 - Double(dist) / Double(maxLen)
+    }
+
+    /// Classic Levenshtein edit distance (two-row DP). Small inputs only.
+    private static func levenshtein(_ a: [Character], _ b: [Character]) -> Int {
+        if a.isEmpty { return b.count }
+        if b.isEmpty { return a.count }
+
+        var prev = Array(0...b.count)
+        var curr = [Int](repeating: 0, count: b.count + 1)
+
+        for i in 1...a.count {
+            curr[0] = i
+            for j in 1...b.count {
+                let cost = a[i - 1] == b[j - 1] ? 0 : 1
+                curr[j] = min(
+                    prev[j] + 1,        // deletion
+                    curr[j - 1] + 1,    // insertion
+                    prev[j - 1] + cost  // substitution
+                )
+            }
+            swap(&prev, &curr)
+        }
+        return prev[b.count]
+    }
+
+    // MARK: - Tokenization
+
+    /// Splits text into non-whitespace tokens and the whitespace runs between
+    /// them, so `reassemble` can restore the exact original spacing.
+    private static func tokenize(_ text: String) -> (tokens: [String], separators: [String]) {
+        var tokens: [String] = []
+        var separators: [String] = []
+        var currentToken = ""
+        var currentSep = ""
+        var inToken = false
+
+        for ch in text {
+            if ch.isWhitespace {
+                if inToken {
+                    tokens.append(currentToken)
+                    currentToken = ""
+                    inToken = false
+                    currentSep = ""
+                }
+                currentSep.append(ch)
+            } else {
+                if !inToken {
+                    // Leading whitespace before the first token becomes separators[0].
+                    separators.append(currentSep)
+                    currentSep = ""
+                    inToken = true
+                }
+                currentToken.append(ch)
+            }
+        }
+        if inToken {
+            tokens.append(currentToken)
+            separators.append(currentSep)  // trailing whitespace (usually empty)
+        } else if !currentSep.isEmpty {
+            separators.append(currentSep)
+        }
+        return (tokens, separators)
+    }
+
+    // MARK: - Affixes
+
+    /// Splits a token into (leadingPunctuation, core, trailingPunctuation).
+    private static func affixes(of token: String) -> (leading: String, trailing: String) {
+        let chars = Array(token)
+        var start = 0
+        var end = chars.count
+        while start < end, !chars[start].isLetter, !chars[start].isNumber { start += 1 }
+        while end > start, !chars[end - 1].isLetter, !chars[end - 1].isNumber { end -= 1 }
+        let leading = String(chars[0..<start])
+        let trailing = String(chars[end..<chars.count])
+        return (leading, trailing)
+    }
+
+    /// The alphanumeric core of a token, with surrounding punctuation removed.
+    private static func core(of token: String) -> String {
+        let (leading, trailing) = affixes(of: token)
+        let start = token.index(token.startIndex, offsetBy: leading.count)
+        let end = token.index(token.endIndex, offsetBy: -trailing.count)
+        return String(token[start..<end])
+    }
+}

--- a/wispr.xcodeproj/project.pbxproj
+++ b/wispr.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		1C74D3322FA632B700208826 /* SFSymbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C74D2F82FA632B700208826 /* SFSymbols.swift */; };
 		1C74D3332FA632B700208826 /* StateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C74D2D82FA632B700208826 /* StateManager.swift */; };
 		1C74D3342FA632B700208826 /* FillerWordCleaner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C74D2F62FA632B700208826 /* FillerWordCleaner.swift */; };
+		AB00000000000000000000B1 /* VocabularyCorrector.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000000000000000000C1 /* VocabularyCorrector.swift */; };
+		AB00000000000000000000B2 /* VocabularyEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB00000000000000000000C2 /* VocabularyEditorView.swift */; };
 		1C74D3352FA632B700208826 /* RecordingOverlayPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C74D2F32FA632B700208826 /* RecordingOverlayPanel.swift */; };
 		1C74D3362FA632B700208826 /* CLIInstallDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C74D2EF2FA632B700208826 /* CLIInstallDialog.swift */; };
 		1C74D3372FA632B700208826 /* HotkeyMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C74D2D42FA632B700208826 /* HotkeyMonitor.swift */; };
@@ -182,6 +184,7 @@
 		1C74D2DB2FA632B700208826 /* UpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateChecker.swift; sourceTree = "<group>"; };
 		1C74D2DD2FA632B700208826 /* ModelRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelRowView.swift; sourceTree = "<group>"; };
 		1C74D2DE2FA632B700208826 /* SuffixEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuffixEditorView.swift; sourceTree = "<group>"; };
+		AB00000000000000000000C2 /* VocabularyEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocabularyEditorView.swift; sourceTree = "<group>"; };
 		1C74D2E02FA632B700208826 /* OnboardingAccessibilityStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingAccessibilityStep.swift; sourceTree = "<group>"; };
 		1C74D2E12FA632B700208826 /* OnboardingCompletionStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingCompletionStep.swift; sourceTree = "<group>"; };
 		1C74D2E22FA632B700208826 /* OnboardingComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingComponents.swift; sourceTree = "<group>"; };
@@ -202,6 +205,7 @@
 		1C74D2F32FA632B700208826 /* RecordingOverlayPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingOverlayPanel.swift; sourceTree = "<group>"; };
 		1C74D2F42FA632B700208826 /* RecordingOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingOverlayView.swift; sourceTree = "<group>"; };
 		1C74D2F62FA632B700208826 /* FillerWordCleaner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FillerWordCleaner.swift; sourceTree = "<group>"; };
+		AB00000000000000000000C1 /* VocabularyCorrector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VocabularyCorrector.swift; sourceTree = "<group>"; };
 		1C74D2F72FA632B700208826 /* PreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewHelpers.swift; sourceTree = "<group>"; };
 		1C74D2F82FA632B700208826 /* SFSymbols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSymbols.swift; sourceTree = "<group>"; };
 		1C74D2F92FA632B700208826 /* UIThemeEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIThemeEngine.swift; sourceTree = "<group>"; };
@@ -422,6 +426,7 @@
 			children = (
 				1C74D2DD2FA632B700208826 /* ModelRowView.swift */,
 				1C74D2DE2FA632B700208826 /* SuffixEditorView.swift */,
+				AB00000000000000000000C2 /* VocabularyEditorView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -474,6 +479,7 @@
 			isa = PBXGroup;
 			children = (
 				1C74D2F62FA632B700208826 /* FillerWordCleaner.swift */,
+				AB00000000000000000000C1 /* VocabularyCorrector.swift */,
 				1C74D2F72FA632B700208826 /* PreviewHelpers.swift */,
 				1C74D2F82FA632B700208826 /* SFSymbols.swift */,
 				1C74D2F92FA632B700208826 /* UIThemeEngine.swift */,
@@ -733,6 +739,8 @@
 				1C74D3322FA632B700208826 /* SFSymbols.swift in Sources */,
 				1C74D3332FA632B700208826 /* StateManager.swift in Sources */,
 				1C74D3342FA632B700208826 /* FillerWordCleaner.swift in Sources */,
+				AB00000000000000000000B1 /* VocabularyCorrector.swift in Sources */,
+				AB00000000000000000000B2 /* VocabularyEditorView.swift in Sources */,
 				1C74D3352FA632B700208826 /* RecordingOverlayPanel.swift in Sources */,
 				1C74D3362FA632B700208826 /* CLIInstallDialog.swift in Sources */,
 				1C74D3372FA632B700208826 /* HotkeyMonitor.swift in Sources */,

--- a/wisprTests/SettingsStoreTests.swift
+++ b/wisprTests/SettingsStoreTests.swift
@@ -306,6 +306,39 @@ struct SettingsStoreTests {
         #expect(store.removeFillerWords == false)
     }
 
+    // MARK: - Custom Vocabulary Tests
+
+    @Test("SettingsStore customVocabulary settings default to disabled and empty")
+    func testCustomVocabularyDefaults() {
+        let defaults = createTestDefaults()
+        let store = SettingsStore(defaults: defaults)
+        #expect(store.customVocabularyEnabled == false)
+        #expect(store.customVocabulary.isEmpty)
+    }
+
+    @Test("SettingsStore persists customVocabularyEnabled and customVocabulary")
+    func testCustomVocabularyPersistence() {
+        let defaults = createTestDefaults()
+        let store = SettingsStore(defaults: defaults)
+        store.customVocabularyEnabled = true
+        store.customVocabulary = ["kubectl", "PyTorch"]
+
+        let newStore = SettingsStore(defaults: defaults)
+        #expect(newStore.customVocabularyEnabled == true, "customVocabularyEnabled should persist")
+        #expect(newStore.customVocabulary == ["kubectl", "PyTorch"], "customVocabulary should persist")
+    }
+
+    @Test("SettingsStore restoreDefaults resets custom vocabulary settings")
+    func testRestoreDefaultsResetsCustomVocabulary() {
+        let defaults = createTestDefaults()
+        let store = SettingsStore(defaults: defaults)
+        store.customVocabularyEnabled = true
+        store.customVocabulary = ["kubectl"]
+        store.restoreDefaults()
+        #expect(store.customVocabularyEnabled == false)
+        #expect(store.customVocabulary.isEmpty)
+    }
+
     // MARK: - Meeting Echo Suppression Tests
 
     @Test("SettingsStore meetingEchoSuppressionEnabled defaults to true")

--- a/wisprTests/StateManagerTests.swift
+++ b/wisprTests/StateManagerTests.swift
@@ -621,6 +621,96 @@ struct StateManagerTests {
         #expect(result == "")
     }
 
+    // MARK: - Custom Vocabulary Correction
+
+    @Test("applyVocabularyCorrection corrects when enabled")
+    func testVocabularyCorrectionEnabled() {
+        let defaults = UserDefaults(suiteName: "test.wispr.vocab.on.\(UUID().uuidString)")!
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.customVocabularyEnabled = true
+        settingsStore.customVocabulary = ["Novaria"]
+
+        let sm = StateManager(
+            audioEngine: AudioEngine(),
+            whisperService: WhisperService(),
+            textInsertionService: TextInsertionService(),
+            textCorrectionService: TextCorrectionService(),
+            hotkeyMonitor: HotkeyMonitor(),
+            permissionManager: PermissionManager(),
+            settingsStore: settingsStore
+        )
+
+        let result = sm.applyVocabularyCorrection(to: "I use novarya daily")
+        #expect(result == "I use Novaria daily")
+    }
+
+    @Test("applyVocabularyCorrection passes text through when disabled")
+    func testVocabularyCorrectionDisabled() {
+        let defaults = UserDefaults(suiteName: "test.wispr.vocab.off.\(UUID().uuidString)")!
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.customVocabularyEnabled = false
+        settingsStore.customVocabulary = ["Novaria"]
+
+        let sm = StateManager(
+            audioEngine: AudioEngine(),
+            whisperService: WhisperService(),
+            textInsertionService: TextInsertionService(),
+            textCorrectionService: TextCorrectionService(),
+            hotkeyMonitor: HotkeyMonitor(),
+            permissionManager: PermissionManager(),
+            settingsStore: settingsStore
+        )
+
+        let result = sm.applyVocabularyCorrection(to: "I use novarya daily")
+        #expect(result == "I use novarya daily")
+    }
+
+    @Test("applyVocabularyCorrection passes text through when the vocabulary is empty")
+    func testVocabularyCorrectionEmptyVocabulary() {
+        let defaults = UserDefaults(suiteName: "test.wispr.vocab.empty.\(UUID().uuidString)")!
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.customVocabularyEnabled = true
+        settingsStore.customVocabulary = []
+
+        let sm = StateManager(
+            audioEngine: AudioEngine(),
+            whisperService: WhisperService(),
+            textInsertionService: TextInsertionService(),
+            textCorrectionService: TextCorrectionService(),
+            hotkeyMonitor: HotkeyMonitor(),
+            permissionManager: PermissionManager(),
+            settingsStore: settingsStore
+        )
+
+        let result = sm.applyVocabularyCorrection(to: "I use novarya daily")
+        #expect(result == "I use novarya daily")
+    }
+
+    @Test("applyVocabularyCorrection uses the detected language in auto-detect mode")
+    func testVocabularyCorrectionDetectedLanguageFallback() {
+        let defaults = UserDefaults(suiteName: "test.wispr.vocab.lang.\(UUID().uuidString)")!
+        let settingsStore = SettingsStore(defaults: defaults)
+        settingsStore.customVocabularyEnabled = true
+        settingsStore.customVocabulary = ["PyTorch"]
+        settingsStore.languageMode = .autoDetect  // languageCode == nil
+
+        let sm = StateManager(
+            audioEngine: AudioEngine(),
+            whisperService: WhisperService(),
+            textInsertionService: TextInsertionService(),
+            textCorrectionService: TextCorrectionService(),
+            hotkeyMonitor: HotkeyMonitor(),
+            permissionManager: PermissionManager(),
+            settingsStore: settingsStore
+        )
+
+        // French pronunciation transcribed by the model; the FR fold ("ill" → /j/)
+        // only applies when the detected language reaches the corrector.
+        let result = sm.applyVocabularyCorrection(
+            to: "on utilise pitorche ici", detectedLanguage: "fr")
+        #expect(result == "on utilise PyTorch ici")
+    }
+
     // MARK: - switchActiveModel
 
     @Test("switchActiveModel no-ops when switching to the current model")

--- a/wisprTests/TranscriptStoreTests.swift
+++ b/wisprTests/TranscriptStoreTests.swift
@@ -26,7 +26,7 @@ struct TranscriptStoreTests {
         )
         original.entries.append(
             MeetingTranscriptEntry(
-                speaker: .others, text: "Hi there",
+                speaker: .others(speakerIndex: nil), text: "Hi there",
                 timestamp: Date(timeIntervalSince1970: 1_700_000_020))
         )
 
@@ -41,7 +41,7 @@ struct TranscriptStoreTests {
         #expect(decoded.entries.count == 2)
         #expect(decoded.entries[0].speaker == .you)
         #expect(decoded.entries[0].text == "Hello")
-        #expect(decoded.entries[1].speaker == .others)
+        #expect(decoded.entries[1].speaker == .others(speakerIndex: nil))
         #expect(decoded.entries[1].text == "Hi there")
         #expect(decoded.asPlainText() == original.asPlainText())
     }

--- a/wisprTests/VocabularyCorrectorTests.swift
+++ b/wisprTests/VocabularyCorrectorTests.swift
@@ -28,7 +28,7 @@ struct VocabularyCorrectorTests {
         var testDescription: String { "\"\(input)\" → \"\(expected)\"" }
     }
 
-    static let novariaVocabulary = ["Novaria"]
+    static nonisolated let novariaVocabulary = ["Novaria"]
 
     // MARK: - Case Normalization (word already recognized, wrong spelling/case)
 
@@ -172,5 +172,20 @@ struct VocabularyCorrectorTests {
     @Test("Corrects a word at the end of the text")
     func matchAtEnd() {
         #expect(VocabularyCorrector.correct("we love novaria", vocabulary: Self.novariaVocabulary) == "we love Novaria")
+    }
+
+    // MARK: - Short Words (fuzzy matching disabled below the key-length floor)
+
+    /// Very short vocabulary words ("Go") produce 1–2 character phonetic keys on
+    /// which the similarity threshold cannot discriminate. Fuzzy matching is
+    /// disabled for them: only an exact case-insensitive spelling still corrects.
+    @Test("Short word: fixes casing on exact spelling but never fuzzy-matches")
+    func shortWordExactOnly() {
+        let vocab = ["Go"]
+        // Exact spelling, wrong case → corrected.
+        #expect(VocabularyCorrector.correct("I write go daily", vocabulary: vocab) == "I write Go daily")
+        // Sound-alike words must NOT be swallowed by a 1-character key.
+        #expect(VocabularyCorrector.correct("le gars est là", vocabulary: vocab) == "le gars est là")
+        #expect(VocabularyCorrector.correct("gay pride", vocabulary: vocab) == "gay pride")
     }
 }

--- a/wisprTests/VocabularyCorrectorTests.swift
+++ b/wisprTests/VocabularyCorrectorTests.swift
@@ -1,0 +1,176 @@
+//
+//  VocabularyCorrectorTests.swift
+//  wispr
+//
+//  Unit tests for VocabularyCorrector utility.
+//
+//  VocabularyCorrector fixes proper nouns / tool names that the ASR model
+//  mis-transcribes ("nova ria", "novarya" → "Novaria") by matching transcription
+//  tokens against a user-provided vocabulary using a phonetic key plus a
+//  normalized edit-distance threshold. "Novaria" is a fictitious placeholder name
+//  used to exercise phonetic matching without referencing any real product.
+//
+
+import Testing
+import Foundation
+@testable import WisprApp
+import WisprCore
+
+@Suite("VocabularyCorrector Tests")
+struct VocabularyCorrectorTests {
+
+    // MARK: - Test Case Types
+
+    /// Input/expected pair for parameterized correct() tests, sharing a vocabulary.
+    struct CorrectCase: Sendable, CustomTestStringConvertible {
+        let input: String
+        let expected: String
+        var testDescription: String { "\"\(input)\" → \"\(expected)\"" }
+    }
+
+    static let novariaVocabulary = ["Novaria"]
+
+    // MARK: - Case Normalization (word already recognized, wrong spelling/case)
+
+    static nonisolated let caseCases: [CorrectCase] = [
+        CorrectCase(input: "I use novaria daily", expected: "I use Novaria daily"),
+        CorrectCase(input: "I use NOVARIA daily", expected: "I use Novaria daily"),
+        CorrectCase(input: "I use Novaria daily", expected: "I use Novaria daily"),
+    ]
+
+    @Test("Normalizes casing of an already-recognized vocabulary word", arguments: caseCases)
+    func caseNormalization(_ c: CorrectCase) {
+        #expect(VocabularyCorrector.correct(c.input, vocabulary: Self.novariaVocabulary) == c.expected)
+    }
+
+    // MARK: - Phonetic Match (single token)
+
+    static nonisolated let phoneticSingleCases: [CorrectCase] = [
+        CorrectCase(input: "I use novarya daily", expected: "I use Novaria daily"),
+        CorrectCase(input: "I use novarïa daily", expected: "I use Novaria daily"),
+    ]
+
+    @Test("Corrects a single mis-transcribed token phonetically", arguments: phoneticSingleCases)
+    func phoneticSingle(_ c: CorrectCase) {
+        #expect(VocabularyCorrector.correct(c.input, vocabulary: Self.novariaVocabulary) == c.expected)
+    }
+
+    // MARK: - Phonetic Match (multi-token / word split by the model)
+
+    static nonisolated let phoneticMultiCases: [CorrectCase] = [
+        CorrectCase(input: "I use nova ria daily", expected: "I use Novaria daily"),
+        CorrectCase(input: "I use nova rya daily", expected: "I use Novaria daily"),
+    ]
+
+    @Test("Corrects a vocabulary word the model split into several tokens", arguments: phoneticMultiCases)
+    func phoneticMulti(_ c: CorrectCase) {
+        #expect(VocabularyCorrector.correct(c.input, vocabulary: Self.novariaVocabulary) == c.expected)
+    }
+
+    // MARK: - Punctuation Preservation
+
+    @Test("Preserves punctuation adjacent to a corrected word")
+    func preservesPunctuation() {
+        #expect(VocabularyCorrector.correct("We chose novaria.", vocabulary: Self.novariaVocabulary) == "We chose Novaria.")
+        #expect(VocabularyCorrector.correct("novaria, right?", vocabulary: Self.novariaVocabulary) == "Novaria, right?")
+    }
+
+    // MARK: - Adjacent Word Preservation (regression)
+
+    /// A strong single-word match must not let a weaker multi-word window
+    /// swallow an innocent neighbouring word ("on kubernetes" must keep "on").
+    @Test("Does not absorb a short neighbouring word into a strong match")
+    func preservesNeighbouringWord() {
+        let vocab = ["Kubernetes"]
+        #expect(VocabularyCorrector.correct("we deployed on kubernetes", vocabulary: vocab) == "we deployed on Kubernetes")
+    }
+
+    /// At equal score the shorter window wins, so a neighbouring word is never
+    /// swallowed even when the longer window would also match the vocabulary.
+    @Test("Does not swallow a real neighbouring word at equal score")
+    func prefersShorterWindowOnTie() {
+        // "PyTorch qui": both "païtorc" and "païtorc qui" score 1.0 for PyTorch,
+        // but the shorter window must win so "qui" survives.
+        #expect(
+            VocabularyCorrector.correct("usiamo païtorc qui", vocabulary: ["PyTorch"], languageCode: "it")
+                == "usiamo PyTorch qui"
+        )
+    }
+
+    // MARK: - Multilingual Pronunciation
+
+    /// A word may be pronounced the user-language way or the English way; both
+    /// should match. "PyTorch" said the French way ("pitorche") and the English
+    /// way ("païtorche") both map to the canonical spelling for a French user.
+    static nonisolated let pytorchCases: [CorrectCase] = [
+        CorrectCase(input: "we use pitorche here", expected: "we use PyTorch here"),   // FR pronunciation
+        CorrectCase(input: "we use païtorche here", expected: "we use PyTorch here"),  // EN pronunciation
+        CorrectCase(input: "we use pytorch here", expected: "we use PyTorch here"),    // near-exact
+    ]
+
+    @Test("Matches both user-language and English pronunciations", arguments: pytorchCases)
+    func multilingualPronunciation(_ c: CorrectCase) {
+        #expect(VocabularyCorrector.correct(c.input, vocabulary: ["PyTorch"], languageCode: "fr") == c.expected)
+    }
+
+    /// The user's language is honored generically, not hardcoded to French.
+    /// An Italian user should still match the English pronunciation of a tech name.
+    @Test("Honors an arbitrary user language plus English (Italian)")
+    func italianUserPlusEnglish() {
+        #expect(VocabularyCorrector.correct("usiamo païtorc qui", vocabulary: ["PyTorch"], languageCode: "it") == "usiamo PyTorch qui")
+    }
+
+    /// A regional code like "en-US" is normalized to its base language.
+    @Test("Normalizes a regional language code")
+    func regionalLanguageCode() {
+        #expect(VocabularyCorrector.correct("we use païtorche here", vocabulary: ["PyTorch"], languageCode: "en-US") == "we use PyTorch here")
+    }
+
+    // MARK: - No False Positives
+
+    static nonisolated let noMatchCases: [CorrectCase] = [
+        CorrectCase(input: "Hello world", expected: "Hello world"),
+        CorrectCase(input: "I like data science", expected: "I like data science"),
+        CorrectCase(input: "the database is ready", expected: "the database is ready"),
+    ]
+
+    @Test("Leaves unrelated words untouched", arguments: noMatchCases)
+    func noFalsePositives(_ c: CorrectCase) {
+        #expect(VocabularyCorrector.correct(c.input, vocabulary: Self.novariaVocabulary) == c.expected)
+    }
+
+    // MARK: - Multiple Vocabulary Entries
+
+    @Test("Corrects the closest of several vocabulary entries")
+    func multipleVocabularyEntries() {
+        let vocab = ["Novaria", "Kubernetes", "Anthropic"]
+        #expect(VocabularyCorrector.correct("I use novaria and kubernetes", vocabulary: vocab) == "I use Novaria and Kubernetes")
+    }
+
+    // MARK: - Edge Cases
+
+    @Test("Returns text unchanged when vocabulary is empty")
+    func emptyVocabulary() {
+        #expect(VocabularyCorrector.correct("I use novaria daily", vocabulary: []) == "I use novaria daily")
+    }
+
+    @Test("Returns empty string for empty input")
+    func emptyInput() {
+        #expect(VocabularyCorrector.correct("", vocabulary: Self.novariaVocabulary) == "")
+    }
+
+    @Test("Ignores empty and whitespace-only vocabulary entries")
+    func ignoresBlankVocabularyEntries() {
+        #expect(VocabularyCorrector.correct("Hello world", vocabulary: ["", "   "]) == "Hello world")
+    }
+
+    @Test("Corrects a word at the start of the text")
+    func matchAtStart() {
+        #expect(VocabularyCorrector.correct("novaria is great", vocabulary: Self.novariaVocabulary) == "Novaria is great")
+    }
+
+    @Test("Corrects a word at the end of the text")
+    func matchAtEnd() {
+        #expect(VocabularyCorrector.correct("we love novaria", vocabulary: Self.novariaVocabulary) == "we love Novaria")
+    }
+}


### PR DESCRIPTION
## Problem

ASR models mangle proper nouns they've never seen: "kubectl" comes out as
"cube cuttle", "PyTorch" loses its casing, rare names get split into several
words. There's no way to teach Wispr the spelling of words that matter to you.

## Solution

A **Custom Vocabulary** list (Settings → After Transcription): any run of 1–3
transcribed words that *sounds like* a vocabulary entry is rewritten to its
canonical spelling. Matching is phonetic (per-language key + edit-distance
threshold, user's language + English so both pronunciations of "PyTorch" work)
and purely lexical — engine-agnostic, applied to both dictation and meeting
transcripts. Details in `VocabularyCorrector.swift`.

## Try it

Enable **Custom Vocabulary** in Settings, add `kubectl` and `PyTorch`, then
dictate *"I deployed the pytorch model with kubectl"* — both come out correctly
spelled, neighbouring words untouched.

Covered by unit tests (corrector, settings persistence, pipeline wiring).

**Note:** first commit is an unrelated one-line fix — `TranscriptStoreTests` no
longer compiled after the `.others(speakerIndex:)` enum change. Can split it
out if preferred.