### PR TITLE
fix(menu): correctly detect installed CLI and hide item on App Store builds

### DIFF
--- a/Sources/WisprApp/UI/MenuBarController.swift
+++ b/Sources/WisprApp/UI/MenuBarController.swift
@@ -309,11 +309,12 @@ final class MenuBarController {
 
     // MARK: - CLI Install Menu Item
 
-    /// Hides the CLI install menu item once the symlink is in place.
+    /// Shows the CLI install menu item only when this build bundles the CLI
+    /// (App Store builds omit it) and the symlink is not already in place.
     func refreshCLIInstallMenuItem() {
-        let installed = isCLIInstalled()
-        cliInstallMenuItem?.isHidden = installed
-        cliInstallSeparator.isHidden = installed
+        let shouldShow = isCLIEmbedded() && !isCLIInstalled()
+        cliInstallMenuItem?.isHidden = !shouldShow
+        cliInstallSeparator.isHidden = !shouldShow
     }
 
     // MARK: - Update Menu Item
@@ -613,16 +614,28 @@ final class MenuBarController {
         stateManager.currentLanguage = mode
     }
 
-    /// Checks whether /usr/local/bin/wispr exists and points to the
-    /// wispr-cli binary inside the current app bundle.
+    /// Absolute path to the CLI binary embedded in the current app bundle.
+    /// App Store builds do not embed it (it is unsandboxed), so this file is
+    /// absent there; Homebrew/Developer ID builds do embed it.
+    private var embeddedCLIPath: String {
+        Bundle.main.bundlePath + "/Contents/Resources/bin/"
+            + CLIInstallDialogView.cliExecutableName
+    }
+
+    /// Whether this build bundles the CLI binary at all.
+    private func isCLIEmbedded() -> Bool {
+        FileManager.default.fileExists(atPath: embeddedCLIPath)
+    }
+
+    /// Checks whether the CLI symlink exists and points to the embedded binary
+    /// inside the current app bundle.
     private func isCLIInstalled() -> Bool {
         let fm = FileManager.default
         guard let dest = try? fm.destinationOfSymbolicLink(atPath: cliSymlinkPath) else {
             return false
         }
-        let expectedDest = Bundle.main.bundlePath + "/Contents/Resources/bin/wispr-cli"
         return URL(fileURLWithPath: dest).resolvingSymlinksInPath().path
-            == URL(fileURLWithPath: expectedDest).resolvingSymlinksInPath().path
+            == URL(fileURLWithPath: embeddedCLIPath).resolvingSymlinksInPath().path
     }
 
     /// Presents the CLI install dialog as a floating window.


### PR DESCRIPTION
## Summary

Fixes the "Install Command Line Tool…" menu item, which had two defects.

### 1. Installed CLI was never detected
`isCLIInstalled()` compared the `/usr/local/bin/wispr` symlink target against a hardcoded `.../bin/wispr-cli` path, but the embedded binary is actually named **`WisprCLI`**. The comparison never matched, so the menu item stayed visible **even after the CLI was successfully installed**.

Now both the install path and the detection path derive from a single `embeddedCLIPath` property that uses `CLIInstallDialogView.cliExecutableName` — the same constant the install dialog uses — so they can't drift apart again.

### 2. Item offered on App Store builds that don't bundle the CLI
App Store builds omit the (unsandboxed) CLI binary, so offering to install it there is a dead end. Added `isCLIEmbedded()`; the item now appears only when the binary is actually present in the bundle:

```swift
let shouldShow = isCLIEmbedded() && !isCLIInstalled()
```

## Verification

Built and ran the app; drove the real status-bar menu via System Events and observed both branches:

| Symlink state | Expected | Observed |
|---|---|---|
| `→ /Applications/Wispr.app/...WisprCLI` (not this build) | item **shown** | ✅ "Install Command Line Tool…" present |
| `→ this build's .../WisprCLI` (installed) | item **hidden** | ✅ item absent |

Under the old code the second case would have kept the item wrongly visible, since `WisprCLI` never matched the hardcoded `wispr-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)