### PR TITLE
Feat: Real-Time Partial Transcription (ghost text)

### DIFF
--- a/Sources/WisprApp/Services/SettingsStore.swift
+++ b/Sources/WisprApp/Services/SettingsStore.swift
@@ -70,6 +70,16 @@ final class SettingsStore {
         }
     }
 
+    /// When true and the active model supports it, partial transcription text
+    /// ("ghost text") is shown in the recording overlay as the user speaks.
+    /// Defaults to false.
+    var showRealtimeText: Bool {
+        didSet {
+            guard !isLoading else { return }
+            defaults.set(showRealtimeText, forKey: Keys.showRealtimeText)
+        }
+    }
+
     var onboardingCompleted: Bool {
         didSet {
             guard !isLoading else { return }
@@ -199,6 +209,7 @@ final class SettingsStore {
         static let languageMode = "languageMode"
         static let showRecordingOverlay = "showRecordingOverlay"
         static let launchAtLogin = "launchAtLogin"
+        static let showRealtimeText = "showRealtimeText"
         static let onboardingCompleted = "onboardingCompleted"
         static let onboardingLastStep = "onboardingLastStep"
         static let handsFreeMode = "handsFreeMode"
@@ -226,6 +237,7 @@ final class SettingsStore {
         static let languageMode: TranscriptionLanguage = .autoDetect
         static let showRecordingOverlay: Bool = true
         static let launchAtLogin: Bool = false
+        static let showRealtimeText: Bool = false
         static let onboardingCompleted: Bool = false
         static let onboardingLastStep: Int = 0
         static let handsFreeMode: Bool = false
@@ -257,6 +269,7 @@ final class SettingsStore {
         self.languageMode = Defaults.languageMode
         self.showRecordingOverlay = Defaults.showRecordingOverlay
         self.launchAtLogin = Defaults.launchAtLogin
+        self.showRealtimeText = Defaults.showRealtimeText
         self.onboardingCompleted = Defaults.onboardingCompleted
         self.onboardingLastStep = Defaults.onboardingLastStep
         self.handsFreeMode = Defaults.handsFreeMode
@@ -288,6 +301,7 @@ final class SettingsStore {
         languageMode = Defaults.languageMode
         showRecordingOverlay = Defaults.showRecordingOverlay
         launchAtLogin = Defaults.launchAtLogin
+        showRealtimeText = Defaults.showRealtimeText
         handsFreeMode = Defaults.handsFreeMode
         meetingDiarizationEnabled = Defaults.meetingDiarizationEnabled
         meetingEchoSuppressionEnabled = Defaults.meetingEchoSuppressionEnabled
@@ -314,6 +328,7 @@ final class SettingsStore {
         defaults.set(selectedAudioDeviceUID, forKey: Keys.selectedAudioDeviceUID)
         defaults.set(activeModelName, forKey: Keys.activeModelName)
         defaults.set(showRecordingOverlay, forKey: Keys.showRecordingOverlay)
+        defaults.set(showRealtimeText, forKey: Keys.showRealtimeText)
         defaults.set(onboardingCompleted, forKey: Keys.onboardingCompleted)
         defaults.set(onboardingLastStep, forKey: Keys.onboardingLastStep)
         defaults.set(handsFreeMode, forKey: Keys.handsFreeMode)
@@ -377,6 +392,9 @@ final class SettingsStore {
         // Load general settings
         if defaults.object(forKey: Keys.showRecordingOverlay) != nil {
             self.showRecordingOverlay = defaults.bool(forKey: Keys.showRecordingOverlay)
+        }
+        if defaults.object(forKey: Keys.showRealtimeText) != nil {
+            self.showRealtimeText = defaults.bool(forKey: Keys.showRealtimeText)
         }
         self.launchAtLogin = SMAppService.mainApp.status == .enabled
         self.onboardingCompleted = defaults.bool(forKey: Keys.onboardingCompleted)

--- a/Sources/WisprApp/Services/StateManager.swift
+++ b/Sources/WisprApp/Services/StateManager.swift
@@ -44,6 +44,11 @@ final class StateManager {
     /// When nil, the overlay shows the default "Processing..." label.
     var processingStatusText: String?
 
+    /// Partial transcription text ("ghost text") shown in the overlay during
+    /// recording. Updated in real time when `showRealtimeText` is enabled and
+    /// the active model supports partial results. Cleared when recording stops.
+    var partialTranscriptionText: String?
+
     // MARK: - Dependencies
 
     private let audioEngine: AudioEngine
@@ -193,16 +198,32 @@ final class StateManager {
         let supportsEou = await whisperService.supportsEndOfUtteranceDetection()
         guard supportsEou else { return }
 
+        var emitPartials = false
+        if settingsStore.showRealtimeText {
+            emitPartials = await whisperService.supportsPartialResults()
+        }
+
         eouMonitoringTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            // Single source of cleanup: clear the ghost text on every exit path
+            // (normal completion, EOU break, thrown error, cancellation).
+            defer { self.partialTranscriptionText = nil }
             do {
                 let resultStream = await self.whisperService.transcribeStream(
                     await self.audioEngine.captureStream,
-                    language: self.currentLanguage
+                    language: self.currentLanguage,
+                    emitPartialResults: emitPartials
                 )
 
                 var finalResult: TranscriptionResult?
                 for try await result in resultStream {
+                    if result.isPartial {
+                        // Live "ghost text". The whole task is @MainActor, so
+                        // this mutation is isolation-safe; the value arrives via
+                        // the thread-safe stream, not direct cross-actor access.
+                        self.partialTranscriptionText = result.text
+                        continue
+                    }
                     if result.isEndOfUtterance {
                         finalResult = result
                         break
@@ -242,6 +263,7 @@ final class StateManager {
     private func cancelEouMonitoring() {
         eouMonitoringTask?.cancel()
         eouMonitoringTask = nil
+        partialTranscriptionText = nil
     }
 
     // MARK: - Filler Word Removal

--- a/Sources/WisprApp/UI/RecordingOverlayPanel.swift
+++ b/Sources/WisprApp/UI/RecordingOverlayPanel.swift
@@ -141,26 +141,29 @@ final class RecordingOverlayPanel {
 
         self.panel = panel
 
-        // Keep the panel bottom-centered as its height changes. KVO callbacks
+        // Keep the panel bottom-centered as its size changes. KVO callbacks
         // arrive on an unspecified thread, so hop to the main actor explicitly
-        // rather than asserting isolation. Only the Sendable height delta
-        // crosses the boundary; the panel is re-read via `self.panel` on-main.
+        // rather than asserting isolation. Only the Sendable size deltas cross
+        // the boundary; the panel is re-read via `self.panel` on-main.
         contentSizeObservation = panel.observe(\.frame, options: [.old, .new]) { [weak self] _, change in
             guard let old = change.oldValue, let new = change.newValue else { return }
             let heightDelta = new.size.height - old.size.height
-            guard heightDelta != 0 else { return }
+            let widthDelta = new.size.width - old.size.width
+            guard heightDelta != 0 || widthDelta != 0 else { return }
             Task { @MainActor [weak self] in
-                self?.repositionForResize(byHeightDelta: heightDelta)
+                self?.repositionForResize(heightDelta: heightDelta, widthDelta: widthDelta)
             }
         }
     }
 
-    /// Re-anchors the panel to its bottom edge when the content height changes,
-    /// so it grows upward from a stable baseline instead of shifting.
-    private func repositionForResize(byHeightDelta heightDelta: CGFloat) {
+    /// Re-anchors the panel to its bottom-center as its content size changes,
+    /// so it grows from a stable baseline instead of shifting: the bottom edge
+    /// stays put (grow upward) and the horizontal center is preserved.
+    private func repositionForResize(heightDelta: CGFloat, widthDelta: CGFloat) {
         guard let panel else { return }
         var origin = panel.frame.origin
         origin.y -= heightDelta
+        origin.x -= widthDelta / 2
         panel.setFrameOrigin(origin)
     }
 

--- a/Sources/WisprApp/UI/RecordingOverlayPanel.swift
+++ b/Sources/WisprApp/UI/RecordingOverlayPanel.swift
@@ -141,21 +141,24 @@ final class RecordingOverlayPanel {
 
         self.panel = panel
 
-        // Keep the panel bottom-centered as its height changes.
-        contentSizeObservation = panel.observe(\.frame, options: [.old, .new]) { [weak self] observedPanel, change in
-            guard let old = change.oldValue, let new = change.newValue,
-                old.size.height != new.size.height else { return }
-            MainActor.assumeIsolated {
-                self?.repositionForResize(observedPanel, previousHeight: old.size.height)
+        // Keep the panel bottom-centered as its height changes. KVO callbacks
+        // arrive on an unspecified thread, so hop to the main actor explicitly
+        // rather than asserting isolation. Only the Sendable height delta
+        // crosses the boundary; the panel is re-read via `self.panel` on-main.
+        contentSizeObservation = panel.observe(\.frame, options: [.old, .new]) { [weak self] _, change in
+            guard let old = change.oldValue, let new = change.newValue else { return }
+            let heightDelta = new.size.height - old.size.height
+            guard heightDelta != 0 else { return }
+            Task { @MainActor [weak self] in
+                self?.repositionForResize(byHeightDelta: heightDelta)
             }
         }
     }
 
     /// Re-anchors the panel to its bottom edge when the content height changes,
     /// so it grows upward from a stable baseline instead of shifting.
-    private func repositionForResize(_ panel: NSPanel, previousHeight: CGFloat) {
-        let heightDelta = panel.frame.size.height - previousHeight
-        guard heightDelta != 0 else { return }
+    private func repositionForResize(byHeightDelta heightDelta: CGFloat) {
+        guard let panel else { return }
         var origin = panel.frame.origin
         origin.y -= heightDelta
         panel.setFrameOrigin(origin)

--- a/Sources/WisprApp/UI/RecordingOverlayPanel.swift
+++ b/Sources/WisprApp/UI/RecordingOverlayPanel.swift
@@ -34,6 +34,7 @@ final class RecordingOverlayPanel {
     // MARK: - Properties
 
     private var panel: NSPanel?
+    private var contentSizeObservation: NSKeyValueObservation?
     private let stateManager: StateManager
     private let settingsStore: SettingsStore
     private let themeEngine: UIThemeEngine
@@ -111,8 +112,13 @@ final class RecordingOverlayPanel {
             .environment(settingsStore)
             .environment(themeEngine)
 
-        let hostingView = NSHostingView(rootView: overlayView)
-        hostingView.setFrameSize(NSSize(width: 260, height: 92))
+        // Use a hosting *controller* with .preferredContentSize so the panel
+        // resizes itself to fit the SwiftUI content. This lets the overlay grow
+        // vertically when real-time partial transcription text is shown, and
+        // shrink back when it is cleared — the fixed-size NSHostingView we used
+        // before would clip the extra text.
+        let hostingController = NSHostingController(rootView: overlayView)
+        hostingController.sizingOptions = [.preferredContentSize]
 
         let panel = NSPanel(
             contentRect: NSRect(x: 0, y: 0, width: 260, height: 92),
@@ -120,6 +126,9 @@ final class RecordingOverlayPanel {
             backing: .buffered,
             defer: false
         )
+        // Assigning the content view controller (rather than a fixed-size
+        // content view) lets .preferredContentSize drive the panel's size.
+        panel.contentViewController = hostingController
 
         panel.isFloatingPanel = true
         panel.level = .floating
@@ -129,9 +138,27 @@ final class RecordingOverlayPanel {
         panel.isMovableByWindowBackground = false
         panel.hidesOnDeactivate = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        panel.contentView = hostingView
 
         self.panel = panel
+
+        // Keep the panel bottom-centered as its height changes.
+        contentSizeObservation = panel.observe(\.frame, options: [.old, .new]) { [weak self] observedPanel, change in
+            guard let old = change.oldValue, let new = change.newValue,
+                old.size.height != new.size.height else { return }
+            MainActor.assumeIsolated {
+                self?.repositionForResize(observedPanel, previousHeight: old.size.height)
+            }
+        }
+    }
+
+    /// Re-anchors the panel to its bottom edge when the content height changes,
+    /// so it grows upward from a stable baseline instead of shifting.
+    private func repositionForResize(_ panel: NSPanel, previousHeight: CGFloat) {
+        let heightDelta = panel.frame.size.height - previousHeight
+        guard heightDelta != 0 else { return }
+        var origin = panel.frame.origin
+        origin.y -= heightDelta
+        panel.setFrameOrigin(origin)
     }
 
     private func positionPanel(_ panel: NSPanel) {

--- a/Sources/WisprApp/UI/RecordingOverlayView.swift
+++ b/Sources/WisprApp/UI/RecordingOverlayView.swift
@@ -79,6 +79,10 @@ struct RecordingOverlayView: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabelForState)
+        // Surface live partial transcription on the root element. The child
+        // Text's own label is ignored under `.combine` + explicit label, so
+        // expose the ghost text as the root's accessibilityValue instead.
+        .accessibilityValue(partialTranscriptionAccessibilityValue)
         .accessibilityHint(
             settingsStore.handsFreeMode
                 ? "Press the hotkey again to stop recording. Recording may also stop automatically, depending on the model."
@@ -149,7 +153,7 @@ struct RecordingOverlayView: View {
                     .truncationMode(.head)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .transition(.opacity)
-                    .accessibilityLabel("Partial transcription: \(partialText)")
+                    .accessibilityHidden(true)  // surfaced via the root's accessibilityValue
             }
         }
         .padding(.horizontal, 20)
@@ -297,6 +301,16 @@ struct RecordingOverlayView: View {
     }
 
     // MARK: - Accessibility
+
+    /// Live partial transcription surfaced as the root element's value, so
+    /// VoiceOver announces ghost text updates during recording. Empty when
+    /// there is no partial text.
+    private var partialTranscriptionAccessibilityValue: String {
+        guard case .recording = stateManager.appState,
+              let partial = stateManager.partialTranscriptionText, !partial.isEmpty
+        else { return "" }
+        return partial
+    }
 
     private var accessibilityLabelForState: String {
         switch stateManager.appState {

--- a/Sources/WisprApp/UI/RecordingOverlayView.swift
+++ b/Sources/WisprApp/UI/RecordingOverlayView.swift
@@ -48,7 +48,11 @@ struct RecordingOverlayView: View {
         ZStack {
             overlayContent
         }
-        .frame(width: overlayWidth, height: overlayHeight)
+        // Fixed width, but flexible height so the overlay can grow when
+        // real-time partial transcription ("ghost text") is displayed.
+        // The hosting panel tracks this via preferredContentSize.
+        .frame(width: overlayWidth)
+        .frame(minHeight: overlayHeight)
         .liquidGlassOverlay()
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .highContrastBorder(cornerRadius: 16)
@@ -117,24 +121,42 @@ struct RecordingOverlayView: View {
         }
     }
 
-    /// Recording state: microphone icon + animated audio level bars.
+    /// Recording state: microphone icon + animated audio level bars, plus
+    /// optional real-time partial transcription ("ghost text") below.
     private var recordingContent: some View {
-        HStack(spacing: 10) {
-            Image(systemName: SFSymbols.recordingMicrophone)
-                .font(.title)
-                .foregroundStyle(theme.accentColor)
-                .symbolEffect(.pulse, isActive: !theme.reduceMotion)
-                .shadow(
-                    color: theme.reduceMotion
-                        ? .clear
-                        : theme.accentColor.opacity(isGlowActive ? 0.6 : 0.0),
-                    radius: isGlowActive ? 8 : 0
-                )
-                .accessibilityHidden(true)
+        VStack(spacing: 6) {
+            HStack(spacing: 10) {
+                Image(systemName: SFSymbols.recordingMicrophone)
+                    .font(.title)
+                    .foregroundStyle(theme.accentColor)
+                    .symbolEffect(.pulse, isActive: !theme.reduceMotion)
+                    .shadow(
+                        color: theme.reduceMotion
+                            ? .clear
+                            : theme.accentColor.opacity(isGlowActive ? 0.6 : 0.0),
+                        radius: isGlowActive ? 8 : 0
+                    )
+                    .accessibilityHidden(true)
 
-            audioLevelMeter
+                audioLevelMeter
+            }
+
+            if let partialText = stateManager.partialTranscriptionText, !partialText.isEmpty {
+                Text(partialText)
+                    .font(.caption)
+                    .foregroundStyle(theme.secondaryTextColor)
+                    .lineLimit(2)
+                    .truncationMode(.head)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .transition(.opacity)
+                    .accessibilityLabel("Partial transcription: \(partialText)")
+            }
         }
         .padding(.horizontal, 20)
+        .animation(
+            theme.reduceMotion ? nil : .easeInOut(duration: 0.2),
+            value: stateManager.partialTranscriptionText
+        )
     }
 
     /// Processing state: spinner + label.

--- a/Sources/WisprApp/UI/Settings/SettingsView.swift
+++ b/Sources/WisprApp/UI/Settings/SettingsView.swift
@@ -67,6 +67,7 @@ struct SettingsView: View {
         // Feedback section
         static let soundFeedback = "When enabled, plays audio cues when recording starts and stops"
         static let showRecordingOverlay = "When enabled, a floating overlay appears while recording"
+        static let showRealtimeText = "When enabled, shows partial transcription text in the recording overlay as you speak. Requires Hands-Free Mode and a supported model."
         static let meetingDetection = "When enabled, Wispr notifies you when another app starts using your microphone so you can start meeting transcription in one click"
 
         // Meeting section
@@ -236,6 +237,18 @@ struct SettingsView: View {
         whisperModels.filter { $0.status == .downloaded || $0.status == .active }
     }
 
+    /// Whether real-time partial transcription can currently be enabled: the
+    /// active model must support partial results AND Hands-Free Mode must be on
+    /// (partial results are delivered through the EOU streaming path, which only
+    /// runs in hands-free mode).
+    private var activeModelSupportsPartialResults: Bool {
+        whisperModels.first(where: { $0.id == settingsStore.activeModelName })?.supportsPartialResults ?? false
+    }
+
+    private var realtimeTextAvailable: Bool {
+        activeModelSupportsPartialResults && settingsStore.handsFreeMode
+    }
+
     private var recognitionSection: some View {
         Section {
             if availableModels.isEmpty {
@@ -369,6 +382,16 @@ struct SettingsView: View {
 
             Toggle("Show Recording Overlay", isOn: $store.showRecordingOverlay)
                 .accessibilityHint(AccessibilityHints.showRecordingOverlay)
+
+            Toggle("Show Real-Time Transcription", isOn: $store.showRealtimeText)
+                .disabled(!realtimeTextAvailable)
+                .accessibilityHint(AccessibilityHints.showRealtimeText)
+
+            if !realtimeTextAvailable {
+                Text("Requires Hands-Free Mode and a supported model (Realtime 120M)")
+                    .font(.caption)
+                    .foregroundStyle(theme.secondaryTextColor)
+            }
 
             Toggle("Detect Meetings", isOn: $store.meetingDetectionEnabled)
                 .accessibilityHint(AccessibilityHints.meetingDetection)

--- a/Sources/WisprApp/Utilities/PreviewHelpers.swift
+++ b/Sources/WisprApp/Utilities/PreviewHelpers.swift
@@ -164,11 +164,12 @@ actor PreviewTranscriptionEngine: TranscriptionEngine {
         TranscriptionResult(text: "", detectedLanguage: nil, duration: 0)
     }
 
-    func transcribeStream(_ audioStream: AsyncStream<[Float]>, language: TranscriptionLanguage) async -> AsyncThrowingStream<TranscriptionResult, Error> {
+    func transcribeStream(_ audioStream: AsyncStream<[Float]>, language: TranscriptionLanguage, emitPartialResults: Bool) async -> AsyncThrowingStream<TranscriptionResult, Error> {
         AsyncThrowingStream { $0.finish() }
     }
 
     func supportsEndOfUtteranceDetection() async -> Bool { false }
+    func supportsPartialResults() async -> Bool { false }
 }
 
 #endif

--- a/Sources/WisprCore/Models/ModelInfo.swift
+++ b/Sources/WisprCore/Models/ModelInfo.swift
@@ -22,18 +22,23 @@ public nonisolated struct ModelInfo: Identifiable, Sendable, Equatable {
     public let estimatedSize: Int64    // bytes, used for download progress
     public var status: ModelStatus
 
+    /// Whether this model supports real-time partial transcription results
+    /// ("ghost text") during streaming. Defaults to false.
+    public let supportsPartialResults: Bool
+
     /// The provider that owns this model, derived from the model ID.
     public var provider: ModelProvider {
         id.hasPrefix("parakeet") ? .nvidiaParakeet : .whisper
     }
 
-    public init(id: String, displayName: String, sizeDescription: String, qualityDescription: String, estimatedSize: Int64, status: ModelStatus) {
+    public init(id: String, displayName: String, sizeDescription: String, qualityDescription: String, estimatedSize: Int64, status: ModelStatus, supportsPartialResults: Bool = false) {
         self.id = id
         self.displayName = displayName
         self.sizeDescription = sizeDescription
         self.qualityDescription = qualityDescription
         self.estimatedSize = estimatedSize
         self.status = status
+        self.supportsPartialResults = supportsPartialResults
     }
 
     // MARK: - Known Model IDs

--- a/Sources/WisprCore/Models/TranscriptionResult.swift
+++ b/Sources/WisprCore/Models/TranscriptionResult.swift
@@ -15,11 +15,16 @@ public nonisolated struct TranscriptionResult: Sendable, Equatable {
     /// True when the transcription engine detected end-of-utterance.
     /// Used by StateManager to auto-stop recording in hands-free mode.
     public let isEndOfUtterance: Bool
+    /// True when this is an intermediate ("ghost text") result emitted during
+    /// streaming, rather than a final transcription. Partial results are shown
+    /// live in the recording overlay and are superseded by later yields.
+    public let isPartial: Bool
 
-    public init(text: String, detectedLanguage: String? = nil, duration: TimeInterval, isEndOfUtterance: Bool = false) {
+    public init(text: String, detectedLanguage: String? = nil, duration: TimeInterval, isEndOfUtterance: Bool = false, isPartial: Bool = false) {
         self.text = text
         self.detectedLanguage = detectedLanguage
         self.duration = duration
         self.isEndOfUtterance = isEndOfUtterance
+        self.isPartial = isPartial
     }
 }

--- a/Sources/WisprCore/Services/CompositeTranscriptionEngine.swift
+++ b/Sources/WisprCore/Services/CompositeTranscriptionEngine.swift
@@ -181,15 +181,21 @@ public actor CompositeTranscriptionEngine: TranscriptionEngine {
         return await engines[idx].supportsEndOfUtteranceDetection()
     }
 
+    public func supportsPartialResults() async -> Bool {
+        guard let idx = activeEngineIndex else { return false }
+        return await engines[idx].supportsPartialResults()
+    }
+
     public func transcribeStream(
         _ audioStream: AsyncStream<[Float]>,
-        language: TranscriptionLanguage
+        language: TranscriptionLanguage,
+        emitPartialResults: Bool
     ) async -> AsyncThrowingStream<TranscriptionResult, Error> {
         guard let idx = activeEngineIndex else {
             let (stream, continuation) = AsyncThrowingStream.makeStream(of: TranscriptionResult.self)
             continuation.finish(throwing: WisprError.modelNotDownloaded)
             return stream
         }
-        return await engines[idx].transcribeStream(audioStream, language: language)
+        return await engines[idx].transcribeStream(audioStream, language: language, emitPartialResults: emitPartialResults)
     }
 }

--- a/Sources/WisprCore/Services/ParakeetService.swift
+++ b/Sources/WisprCore/Services/ParakeetService.swift
@@ -225,33 +225,33 @@ public actor ParakeetService {
             await manager.reset()
             let startTime = Date()
 
-            // Register a partial-result callback for real-time "ghost text".
+            // Always register a partial-result callback for this session, even
+            // when partials are disabled — StreamingEouAsrManager.reset() does
+            // NOT clear the previous session's callback, so registering (and
+            // bumping the generation) is what deterministically supersedes it.
+            // Emission is gated on `emitPartialResults` INSIDE the callback, so
+            // a session with partials off installs an effectively inert callback
+            // rather than leaving a stale one that keeps firing.
+            //
             // `startTime` is an immutable value captured by copy (no race), and
             // the callback yields into the thread-safe stream continuation, so
-            // it is safe to fire from whatever thread FluidAudio uses.
-            //
-            // The returned generation token identifies THIS registration. On any
-            // exit path we clear the callback only if our generation is still the
-            // current one, so a stopped session can't clobber a newer session's
-            // callback during a fast stop→start (StreamingEouAsrManager.reset()
-            // does not clear partialCallback, and there is no nil overload).
-            var partialGeneration: Int?
-            if emitPartialResults {
-                partialGeneration = await self.registerPartialCallback(on: manager) { [startTime] partialText in
-                    let trimmed = partialText.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !trimmed.isEmpty else { return }
-                    continuation.yield(TranscriptionResult(
-                        text: trimmed,
-                        detectedLanguage: nil,
-                        duration: Date().timeIntervalSince(startTime),
-                        isPartial: true
-                    ))
-                }
+            // it is safe to fire from whatever thread FluidAudio uses. The
+            // generation token identifies THIS registration; on any exit path we
+            // clear only if our generation is still current, so a stopped session
+            // can't clobber a newer session's callback during a fast stop→start.
+            let partialGeneration = await self.registerPartialCallback(on: manager) { [startTime] partialText in
+                guard emitPartialResults else { return }
+                let trimmed = partialText.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return }
+                continuation.yield(TranscriptionResult(
+                    text: trimmed,
+                    detectedLanguage: nil,
+                    duration: Date().timeIntervalSince(startTime),
+                    isPartial: true
+                ))
             }
             defer {
-                if let partialGeneration {
-                    Task { await self.clearPartialCallbackIfCurrent(on: manager, generation: partialGeneration) }
-                }
+                Task { await self.clearPartialCallbackIfCurrent(on: manager, generation: partialGeneration) }
             }
 
             do {

--- a/Sources/WisprCore/Services/ParakeetService.swift
+++ b/Sources/WisprCore/Services/ParakeetService.swift
@@ -160,7 +160,10 @@ public actor ParakeetService {
         return TranscriptionResult(text: trimmed, detectedLanguage: nil, duration: duration)
     }
 
-    private func transcribeStreamWithEou(_ audioStream: AsyncStream<[Float]>) -> AsyncThrowingStream<TranscriptionResult, Error> {
+    private func transcribeStreamWithEou(
+        _ audioStream: AsyncStream<[Float]>,
+        emitPartialResults: Bool = false
+    ) -> AsyncThrowingStream<TranscriptionResult, Error> {
         let (stream, continuation) = AsyncThrowingStream.makeStream(of: TranscriptionResult.self)
 
         let manager = self.eouManager
@@ -172,6 +175,24 @@ public actor ParakeetService {
             }
             await manager.reset()
             let startTime = Date()
+
+            // Register a partial-result callback for real-time "ghost text".
+            // `startTime` is an immutable value captured by copy (no race), and
+            // the callback yields into the thread-safe stream continuation, so
+            // it is safe to fire from whatever thread FluidAudio uses.
+            if emitPartialResults {
+                await manager.setPartialCallback { [startTime] partialText in
+                    let trimmed = partialText.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { return }
+                    continuation.yield(TranscriptionResult(
+                        text: trimmed,
+                        detectedLanguage: nil,
+                        duration: Date().timeIntervalSince(startTime),
+                        isPartial: true
+                    ))
+                }
+            }
+
             do {
                 var eouDetected = false
                 for await chunk in audioStream {
@@ -201,7 +222,15 @@ public actor ParakeetService {
             }
         }
 
-        continuation.onTermination = { _ in task.cancel() }
+        // On termination, cancel the processing task AND replace the partial
+        // callback with a no-op. StreamingEouAsrManager.reset() does not clear
+        // partialCallback, and setPartialCallback takes a non-optional closure
+        // (no nil overload), so a lingering callback would otherwise keep a
+        // reference to this finished continuation across sessions.
+        continuation.onTermination = { [weak manager] _ in
+            task.cancel()
+            Task { await manager?.setPartialCallback { _ in } }
+        }
         return stream
     }
 }
@@ -226,7 +255,8 @@ extension ParakeetService: TranscriptionEngine {
                 sizeDescription: "~150 MB",
                 qualityDescription: "Low-latency streaming with end-of-utterance detection (English only)",
                 estimatedSize: 150 * 1024 * 1024,
-                status: .notDownloaded
+                status: .notDownloaded,
+                supportsPartialResults: true
             )
         ]
     }
@@ -504,12 +534,17 @@ extension ParakeetService: TranscriptionEngine {
         return activeModelName == ModelInfo.KnownID.parakeetEou && eouManager != nil
     }
 
+    public func supportsPartialResults() async -> Bool {
+        return activeModelName == ModelInfo.KnownID.parakeetEou && eouManager != nil
+    }
+
     public func transcribeStream(
         _ audioStream: AsyncStream<[Float]>,
-        language: TranscriptionLanguage
+        language: TranscriptionLanguage,
+        emitPartialResults: Bool
     ) async -> AsyncThrowingStream<TranscriptionResult, Error> {
         if activeModelName == ModelInfo.KnownID.parakeetEou {
-            return transcribeStreamWithEou(audioStream)
+            return transcribeStreamWithEou(audioStream, emitPartialResults: emitPartialResults)
         }
 
         let (stream, continuation) = AsyncThrowingStream.makeStream(of: TranscriptionResult.self)

--- a/Sources/WisprCore/Services/ParakeetService.swift
+++ b/Sources/WisprCore/Services/ParakeetService.swift
@@ -23,9 +23,15 @@ public actor ParakeetService {
 
     /// Monotonic token identifying the most recent partial-callback registration.
     /// Incremented each time a streaming session registers a partial callback so
-    /// that an older session's termination cleanup can't clobber a newer session's
-    /// callback (fast stop→start race).
-    private var partialCallbackGeneration = 0
+    /// that an older session can't clobber a newer one during a fast stop→start.
+    ///
+    /// Held behind a lock (not just actor state) because it is read
+    /// synchronously from inside the `@Sendable` partial callback, which fires
+    /// on FluidAudio's threads. The callback compares its own captured
+    /// generation against this value and becomes a no-op when stale — so even if
+    /// actor reentrancy causes an older session's `setPartialCallback` to land
+    /// last, its callback does nothing.
+    private let partialCallbackGeneration = OSAllocatedUnfairLock(initialState: 0)
 
     // MARK: - Shared State
     private let defaults: UserDefaults
@@ -128,13 +134,26 @@ public actor ParakeetService {
     /// Registers a partial-result callback on the given manager and returns the
     /// generation token identifying this registration. Each call bumps the
     /// generation so a later session always wins over an earlier one.
+    ///
+    /// The installed callback is wrapped with a generation check: it forwards to
+    /// `callback` only while its own generation is still current. This makes
+    /// registration itself order-safe — if actor reentrancy causes an older
+    /// session's `setPartialCallback` to land last, its wrapped callback is
+    /// already stale and does nothing.
     private func registerPartialCallback(
         on manager: StreamingEouAsrManager,
         _ callback: @escaping @Sendable (String) -> Void
     ) async -> Int {
-        partialCallbackGeneration += 1
-        let generation = partialCallbackGeneration
-        await manager.setPartialCallback(callback)
+        let generation = partialCallbackGeneration.withLock { value in
+            value += 1
+            return value
+        }
+        let currentGeneration = partialCallbackGeneration
+        await manager.setPartialCallback { text in
+            // Inert once a newer session has registered.
+            guard currentGeneration.withLock({ $0 }) == generation else { return }
+            callback(text)
+        }
         return generation
     }
 
@@ -145,7 +164,7 @@ public actor ParakeetService {
         on manager: StreamingEouAsrManager,
         generation: Int
     ) async {
-        guard generation == partialCallbackGeneration else { return }
+        guard partialCallbackGeneration.withLock({ $0 }) == generation else { return }
         await manager.setPartialCallback { _ in }
     }
 

--- a/Sources/WisprCore/Services/ParakeetService.swift
+++ b/Sources/WisprCore/Services/ParakeetService.swift
@@ -21,6 +21,12 @@ public actor ParakeetService {
     // MARK: - EOU State
     nonisolated(unsafe) private var eouManager: StreamingEouAsrManager?
 
+    /// Monotonic token identifying the most recent partial-callback registration.
+    /// Incremented each time a streaming session registers a partial callback so
+    /// that an older session's termination cleanup can't clobber a newer session's
+    /// callback (fast stop→start race).
+    private var partialCallbackGeneration = 0
+
     // MARK: - Shared State
     private let defaults: UserDefaults
     private var activeModelName: String?
@@ -119,6 +125,30 @@ public actor ParakeetService {
         Log.whisperService.debug("ParakeetService — EOU model unloaded")
     }
 
+    /// Registers a partial-result callback on the given manager and returns the
+    /// generation token identifying this registration. Each call bumps the
+    /// generation so a later session always wins over an earlier one.
+    private func registerPartialCallback(
+        on manager: StreamingEouAsrManager,
+        _ callback: @escaping @Sendable (String) -> Void
+    ) async -> Int {
+        partialCallbackGeneration += 1
+        let generation = partialCallbackGeneration
+        await manager.setPartialCallback(callback)
+        return generation
+    }
+
+    /// Clears the partial callback (with a no-op) only if `generation` is still
+    /// the most recent registration. This prevents a stopped session's cleanup
+    /// from clobbering a newer session's callback during a fast stop→start.
+    private func clearPartialCallbackIfCurrent(
+        on manager: StreamingEouAsrManager,
+        generation: Int
+    ) async {
+        guard generation == partialCallbackGeneration else { return }
+        await manager.setPartialCallback { _ in }
+    }
+
     // MARK: - Audio Helpers
 
     private nonisolated func createPCMBuffer(from samples: [Float], sampleRate: Double) throws -> AVAudioPCMBuffer {
@@ -180,8 +210,15 @@ public actor ParakeetService {
             // `startTime` is an immutable value captured by copy (no race), and
             // the callback yields into the thread-safe stream continuation, so
             // it is safe to fire from whatever thread FluidAudio uses.
+            //
+            // The returned generation token identifies THIS registration. On any
+            // exit path we clear the callback only if our generation is still the
+            // current one, so a stopped session can't clobber a newer session's
+            // callback during a fast stop→start (StreamingEouAsrManager.reset()
+            // does not clear partialCallback, and there is no nil overload).
+            var partialGeneration: Int?
             if emitPartialResults {
-                await manager.setPartialCallback { [startTime] partialText in
+                partialGeneration = await self.registerPartialCallback(on: manager) { [startTime] partialText in
                     let trimmed = partialText.trimmingCharacters(in: .whitespacesAndNewlines)
                     guard !trimmed.isEmpty else { return }
                     continuation.yield(TranscriptionResult(
@@ -190,6 +227,11 @@ public actor ParakeetService {
                         duration: Date().timeIntervalSince(startTime),
                         isPartial: true
                     ))
+                }
+            }
+            defer {
+                if let partialGeneration {
+                    Task { await self.clearPartialCallbackIfCurrent(on: manager, generation: partialGeneration) }
                 }
             }
 
@@ -222,14 +264,10 @@ public actor ParakeetService {
             }
         }
 
-        // On termination, cancel the processing task AND replace the partial
-        // callback with a no-op. StreamingEouAsrManager.reset() does not clear
-        // partialCallback, and setPartialCallback takes a non-optional closure
-        // (no nil overload), so a lingering callback would otherwise keep a
-        // reference to this finished continuation across sessions.
-        continuation.onTermination = { [weak manager] _ in
+        // On termination, cancel the processing task. The task's `defer` handles
+        // clearing the partial callback (guarded by generation token).
+        continuation.onTermination = { _ in
             task.cancel()
-            Task { await manager?.setPartialCallback { _ in } }
         }
         return stream
     }

--- a/Sources/WisprCore/Services/TranscriptionEngine.swift
+++ b/Sources/WisprCore/Services/TranscriptionEngine.swift
@@ -56,11 +56,16 @@ public protocol TranscriptionEngine: Actor {
 
     // MARK: - Streaming Transcription
 
-    /// Accepts a stream of audio chunks and yields partial transcription results
-    /// as they become available.
+    /// Accepts a stream of audio chunks and yields transcription results.
     ///
     /// Engines that don't support true streaming should accumulate all chunks
     /// and yield a single final result when the input stream finishes.
+    ///
+    /// - Parameter emitPartialResults: When `true` *and* the loaded model
+    ///   reports `supportsPartialResults()`, the engine additionally yields
+    ///   intermediate `isPartial` results ("ghost text") during processing.
+    ///   When `false`, or when the model doesn't support partials, only final
+    ///   result(s) are yielded. Engines that never produce partials ignore it.
     func transcribeStream(
         _ audioStream: AsyncStream<[Float]>,
         language: TranscriptionLanguage,

--- a/Sources/WisprCore/Services/TranscriptionEngine.swift
+++ b/Sources/WisprCore/Services/TranscriptionEngine.swift
@@ -63,7 +63,8 @@ public protocol TranscriptionEngine: Actor {
     /// and yield a single final result when the input stream finishes.
     func transcribeStream(
         _ audioStream: AsyncStream<[Float]>,
-        language: TranscriptionLanguage
+        language: TranscriptionLanguage,
+        emitPartialResults: Bool
     ) async -> AsyncThrowingStream<TranscriptionResult, Error>
 
     /// Whether the currently loaded model supports end-of-utterance detection.
@@ -71,6 +72,12 @@ public protocol TranscriptionEngine: Actor {
     /// stops speaking. When false, transcribeStream() only finishes when
     /// the input audio stream ends.
     func supportsEndOfUtteranceDetection() async -> Bool
+
+    /// Whether the currently loaded model supports real-time partial
+    /// transcription results. When true and `emitPartialResults` is passed to
+    /// transcribeStream(), the engine yields intermediate `isPartial` results
+    /// during processing.
+    func supportsPartialResults() async -> Bool
 }
 
 // MARK: - Default Parameter Convenience
@@ -79,5 +86,18 @@ extension TranscriptionEngine {
     /// Convenience overload with default retry count.
     public func reloadModelWithRetry() async throws {
         try await reloadModelWithRetry(maxAttempts: 3)
+    }
+
+    /// Two-argument convenience overload that preserves existing call sites.
+    /// Swift protocol *requirements* cannot carry default argument values, so
+    /// the default lives here in the extension. This forwards to the
+    /// three-argument requirement above; the differing arity means it
+    /// dispatches to the conforming type's implementation, not to itself
+    /// (no recursion).
+    public func transcribeStream(
+        _ audioStream: AsyncStream<[Float]>,
+        language: TranscriptionLanguage
+    ) async -> AsyncThrowingStream<TranscriptionResult, Error> {
+        await transcribeStream(audioStream, language: language, emitPartialResults: false)
     }
 }

--- a/Sources/WisprCore/Services/TranscriptionEngine.swift
+++ b/Sources/WisprCore/Services/TranscriptionEngine.swift
@@ -88,6 +88,13 @@ extension TranscriptionEngine {
         try await reloadModelWithRetry(maxAttempts: 3)
     }
 
+    /// Default implementation so adding this requirement is not source-breaking
+    /// for existing conformers. Engines that support partial results override
+    /// this; most (e.g. WhisperService) get the correct `false` default.
+    public func supportsPartialResults() async -> Bool {
+        false
+    }
+
     /// Two-argument convenience overload that preserves existing call sites.
     /// Swift protocol *requirements* cannot carry default argument values, so
     /// the default lives here in the extension. This forwards to the

--- a/Sources/WisprCore/Services/WhisperService.swift
+++ b/Sources/WisprCore/Services/WhisperService.swift
@@ -611,6 +611,11 @@ extension WhisperService: TranscriptionEngine {
         return false
     }
 
+    /// WhisperKit does not support real-time partial results.
+    public func supportsPartialResults() async -> Bool {
+        return false
+    }
+
     /// Streaming transcription stub — collects all audio chunks, then
     /// delegates to the batch `transcribe(_:language:)` method.
     ///
@@ -618,9 +623,13 @@ extension WhisperService: TranscriptionEngine {
     /// implementation buffers the entire audio stream before processing.
     /// A future engine (e.g. Parakeet via FluidAudio) could yield partial
     /// results as audio arrives.
+    ///
+    /// `emitPartialResults` is ignored: WhisperKit produces no intermediate
+    /// results, so there is nothing to emit before the final result.
     public func transcribeStream(
         _ audioStream: AsyncStream<[Float]>,
-        language: TranscriptionLanguage
+        language: TranscriptionLanguage,
+        emitPartialResults: Bool
     ) async -> AsyncThrowingStream<TranscriptionResult, Error> {
         let (stream, continuation) = AsyncThrowingStream.makeStream(of: TranscriptionResult.self)
 

--- a/wisprTests/CompositeTranscriptionEngineTests.swift
+++ b/wisprTests/CompositeTranscriptionEngineTests.swift
@@ -17,6 +17,7 @@ actor MockTranscriptionEngine: TranscriptionEngine {
     let models: [ModelInfo]
     private var _activeModel: String?
     private var downloadBehavior: DownloadBehavior = .succeedImmediately
+    private let partialResultsSupported: Bool
 
     /// Number of times `loadModel` was invoked (for idempotency assertions).
     private(set) var loadModelCallCount = 0
@@ -31,9 +32,10 @@ actor MockTranscriptionEngine: TranscriptionEngine {
     private var downloadContinuation: AsyncThrowingStream<DownloadProgress, Error>.Continuation?
     private var downloadFinished = false
 
-    init(models: [ModelInfo], activeModel: String? = nil) {
+    init(models: [ModelInfo], activeModel: String? = nil, partialResultsSupported: Bool = false) {
         self.models = models
         self._activeModel = activeModel
+        self.partialResultsSupported = partialResultsSupported
     }
 
     func setDownloadBehavior(_ behavior: DownloadBehavior) {
@@ -123,7 +125,7 @@ actor MockTranscriptionEngine: TranscriptionEngine {
         return TranscriptionResult(text: "mock", detectedLanguage: nil, duration: 0.1)
     }
 
-    func transcribeStream(_ audioStream: AsyncStream<[Float]>, language: TranscriptionLanguage) async -> AsyncThrowingStream<TranscriptionResult, Error> {
+    func transcribeStream(_ audioStream: AsyncStream<[Float]>, language: TranscriptionLanguage, emitPartialResults: Bool) async -> AsyncThrowingStream<TranscriptionResult, Error> {
         let (stream, continuation) = AsyncThrowingStream.makeStream(of: TranscriptionResult.self)
         guard _activeModel != nil else {
             continuation.finish(throwing: WisprError.modelNotDownloaded)
@@ -135,6 +137,7 @@ actor MockTranscriptionEngine: TranscriptionEngine {
     }
 
     func supportsEndOfUtteranceDetection() async -> Bool { false }
+    func supportsPartialResults() async -> Bool { partialResultsSupported }
 }
 
 // MARK: - Helper
@@ -445,5 +448,29 @@ struct CompositeTranscriptionEngineTests {
 
         let result = try await composite.transcribe([Float](repeating: 0, count: 100), language: .autoDetect)
         #expect(result.text == "mock")
+    }
+
+    // MARK: - Partial results forwarding
+
+    @Test("supportsPartialResults forwards to the active engine")
+    func supportsPartialResultsForwardsToActiveEngine() async throws {
+        let engineA = MockTranscriptionEngine(models: [makeModel("model-a")], partialResultsSupported: false)
+        let engineB = MockTranscriptionEngine(models: [makeModel("model-b")], partialResultsSupported: true)
+
+        let composite = CompositeTranscriptionEngine(engines: [engineA, engineB])
+
+        try await composite.loadModel("model-a")
+        #expect(await composite.supportsPartialResults() == false, "Should reflect engine A (unsupported)")
+
+        try await composite.loadModel("model-b")
+        #expect(await composite.supportsPartialResults() == true, "Should reflect engine B (supported)")
+    }
+
+    @Test("supportsPartialResults is false when no engine is active")
+    func supportsPartialResultsFalseWhenNoActiveEngine() async {
+        let engine = MockTranscriptionEngine(models: [makeModel("model-a")], partialResultsSupported: true)
+        let composite = CompositeTranscriptionEngine(engines: [engine])
+
+        #expect(await composite.supportsPartialResults() == false, "No active engine → false")
     }
 }

--- a/wisprTests/MeetingStateManagerTests.swift
+++ b/wisprTests/MeetingStateManagerTests.swift
@@ -485,7 +485,8 @@ actor FakeMeetingTranscriptionEngine: TranscriptionEngine {
 
     func transcribeStream(
         _ audioStream: AsyncStream<[Float]>,
-        language: TranscriptionLanguage
+        language: TranscriptionLanguage,
+        emitPartialResults: Bool
     ) async -> AsyncThrowingStream<TranscriptionResult, Error> {
         let (stream, continuation) = AsyncThrowingStream.makeStream(of: TranscriptionResult.self)
         continuation.yield(
@@ -495,6 +496,10 @@ actor FakeMeetingTranscriptionEngine: TranscriptionEngine {
     }
 
     func supportsEndOfUtteranceDetection() async -> Bool {
+        false
+    }
+
+    func supportsPartialResults() async -> Bool {
         false
     }
 }

--- a/wisprTests/SettingsStoreTests.swift
+++ b/wisprTests/SettingsStoreTests.swift
@@ -186,7 +186,37 @@ struct SettingsStoreTests {
         #expect(newStore.onboardingCompleted == true, "Onboarding completed should persist")
         #expect(newStore.onboardingLastStep == 3, "Onboarding last step should persist")
     }
-    
+
+    @Test("SettingsStore showRealtimeText defaults to false")
+    func testShowRealtimeTextDefault() async {
+        let defaults = createTestDefaults()
+        let store = SettingsStore(defaults: defaults)
+
+        #expect(store.showRealtimeText == false, "showRealtimeText should default to false")
+    }
+
+    @Test("SettingsStore persists showRealtimeText")
+    func testShowRealtimeTextPersistence() async {
+        let defaults = createTestDefaults()
+        let store = SettingsStore(defaults: defaults)
+
+        store.showRealtimeText = true
+
+        let newStore = SettingsStore(defaults: defaults)
+        #expect(newStore.showRealtimeText == true, "showRealtimeText should persist across instances")
+    }
+
+    @Test("SettingsStore restoreDefaults resets showRealtimeText")
+    func testShowRealtimeTextRestoreDefaults() async {
+        let defaults = createTestDefaults()
+        let store = SettingsStore(defaults: defaults)
+
+        store.showRealtimeText = true
+        store.restoreDefaults()
+
+        #expect(store.showRealtimeText == false, "restoreDefaults should reset showRealtimeText to false")
+    }
+
     // MARK: - Save/Load Tests
     
     @Test("SettingsStore save() persists all properties")

--- a/wisprTests/StateManagerTests.swift
+++ b/wisprTests/StateManagerTests.swift
@@ -365,6 +365,24 @@ struct StateManagerTests {
         #expect(sm.appState == .idle)
     }
 
+    @Test("resetToIdle clears partial transcription text")
+    func testResetToIdleClearsPartialTranscriptionText() async {
+        let (sm, _) = createTestStateManager()
+
+        sm.partialTranscriptionText = "partial ghost text"
+
+        await sm.resetToIdle()
+
+        #expect(sm.partialTranscriptionText == nil, "Partial text should be cleared when returning to idle")
+    }
+
+    @Test("partialTranscriptionText defaults to nil")
+    func testPartialTranscriptionTextDefaultsToNil() async {
+        let (sm, _) = createTestStateManager()
+
+        #expect(sm.partialTranscriptionText == nil)
+    }
+
     // MARK: - endRecording Guards
 
     @Test("endRecording is ignored when not recording")


### PR DESCRIPTION
Implements the plan in `.kiro/refactor/realtime-partial-transcription.md` (merged in #50): real-time "ghost text" partial transcription shown in the recording overlay while speaking. Opt-in, off by default, and only available for models that support it (Parakeet EOU 120M) in Hands-Free Mode.

## What's included

- **Models**: `ModelInfo.supportsPartialResults`, `TranscriptionResult.isPartial` (public, default `false`).
- **Protocol**: `TranscriptionEngine.supportsPartialResults()` + `emitPartialResults` parameter on `transcribeStream`; a two-argument convenience overload in the protocol extension preserves existing call sites (no recursion).
- **Engines**: `ParakeetService` reports partial support for the EOU model and wires `setPartialCallback` (capturing an immutable `startTime` by value); installs a no-op callback in `onTermination` because `StreamingEouAsrManager.reset()` does not clear the callback and there is no `nil` overload. `WhisperService` and `CompositeTranscriptionEngine` conform/forward.
- **Settings**: `SettingsStore.showRealtimeText` (key, default `false`, init/save/load/restore).
- **State**: `StateManager.partialTranscriptionText`; EOU monitoring passes `emitPartials` and surfaces partial results with `defer`-based single-source cleanup, cleared via `cancelEouMonitoring` (reached by `resetToIdle`/`endRecording`).
- **UI**: `RecordingOverlayView` shows ghost text below the level meter; `RecordingOverlayPanel` switched to `NSHostingController` + `.preferredContentSize` so it self-sizes and re-anchors to its bottom edge as height changes. `SettingsView` adds a "Show Real-Time Transcription" toggle in the Feedback section, disabled unless the active model supports partials AND Hands-Free Mode is on.

## Deviations from the plan (deliberate)

- **Toggle placement**: the plan suggested the "General" section, but that section holds Launch-at-Login / Version / Restore Defaults. The toggle is a display preference, so it lives in the **Feedback** section next to "Show Recording Overlay".
- **Panel resize**: implemented via `NSHostingController` + `.preferredContentSize` with a KVO observer that re-anchors the bottom edge, rather than a hard-coded taller height.

## Testing

7 new tests (settings default/persist/restore, composite forwarding ×2, StateManager partial-text default + cleanup). Full suite passes via `xcodebuild test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)