### PR TITLE
feat(meeting): reveal saved transcripts folder from Settings

### DIFF
--- a/Sources/WisprApp/UI/Settings/SettingsView.swift
+++ b/Sources/WisprApp/UI/Settings/SettingsView.swift
@@ -6,7 +6,6 @@
 //  Recognition, After Transcription, Feedback, and General.
 //
 
-import AppKit
 import SwiftUI
 import WisprCore
 import os
@@ -89,6 +88,7 @@ struct SettingsView: View {
     @Environment(HotkeyMonitor.self) private var hotkeyMonitor: HotkeyMonitor
     @Environment(TextCorrectionService.self) private var textCorrectionService:
         TextCorrectionService
+    @Environment(\.openURL) private var openURL
 
     @State private var audioDevices: [AudioInputDevice] = []
     @State private var whisperModels: [ModelInfo] = []
@@ -437,8 +437,10 @@ struct SettingsView: View {
 
     /// Home-abbreviated path to the folder where meeting transcripts are saved.
     private var transcriptsFolderPath: String {
-        (TranscriptStore.directory.path(percentEncoded: false) as NSString)
-            .abbreviatingWithTildeInPath
+        let path = TranscriptStore.directory.path(percentEncoded: false)
+        let home = FileManager.default.homeDirectoryForCurrentUser.path(percentEncoded: false)
+        guard path.hasPrefix(home) else { return path }
+        return "~" + path.dropFirst(home.count)
     }
 
     /// Reveals the transcripts folder in Finder, creating it first if no meeting
@@ -446,7 +448,7 @@ struct SettingsView: View {
     private func openTranscriptsFolder() {
         let dir = TranscriptStore.directory
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        NSWorkspace.shared.open(dir)
+        openURL(dir)
     }
 
     // MARK: - General Section

--- a/Sources/WisprApp/UI/Settings/SettingsView.swift
+++ b/Sources/WisprApp/UI/Settings/SettingsView.swift
@@ -6,6 +6,7 @@
 //  Recognition, After Transcription, Feedback, and General.
 //
 
+import AppKit
 import SwiftUI
 import WisprCore
 import os
@@ -74,6 +75,8 @@ struct SettingsView: View {
             "When enabled, the meeting transcript labels remote participants as Speaker 1, Speaker 2, and so on using on-device diarization"
         static let meetingEchoSuppression =
             "When enabled, speech from remote participants that leaks into your microphone is not transcribed a second time as your own speech"
+        static let openTranscriptsFolder =
+            "Opens the folder where saved meeting transcripts are stored in Finder"
 
         // General section
         static let launchAtLogin = "When enabled, Wispr starts automatically when you log in"
@@ -403,6 +406,24 @@ struct SettingsView: View {
             )
             .font(.caption)
             .foregroundStyle(theme.secondaryTextColor)
+
+            Divider()
+
+            HStack {
+                Text("Saved Transcripts")
+                    .foregroundStyle(theme.primaryTextColor)
+                Spacer()
+                Button("Open Folder") {
+                    openTranscriptsFolder()
+                }
+                .accessibilityHint(AccessibilityHints.openTranscriptsFolder)
+            }
+
+            Text(transcriptsFolderPath)
+                .font(.caption)
+                .foregroundStyle(theme.secondaryTextColor)
+                .textSelection(.enabled)
+                .accessibilityLabel("Transcripts are saved to \(transcriptsFolderPath)")
         } header: {
             SectionHeader(
                 title: "Meeting",
@@ -410,6 +431,22 @@ struct SettingsView: View {
                 tint: .indigo
             )
         }
+    }
+
+    // MARK: - Transcripts Folder
+
+    /// Home-abbreviated path to the folder where meeting transcripts are saved.
+    private var transcriptsFolderPath: String {
+        (TranscriptStore.directory.path(percentEncoded: false) as NSString)
+            .abbreviatingWithTildeInPath
+    }
+
+    /// Reveals the transcripts folder in Finder, creating it first if no meeting
+    /// has been saved yet so the button never opens a missing directory.
+    private func openTranscriptsFolder() {
+        let dir = TranscriptStore.directory
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        NSWorkspace.shared.open(dir)
     }
 
     // MARK: - General Section


### PR DESCRIPTION
Closes #82

Meeting transcripts are auto-saved on Stop (#67) as JSON inside the app's sandbox container, which users can't realistically find (`~/Library` is hidden and the path is buried in the container).

This adds discoverability from **Settings → Meeting**, per your call on #82 (button + displayed path only, no custom location, sandbox left intact):

- An **"Open Folder"** button that reveals the transcripts directory in Finder. It opens the app's **own** container folder via `NSWorkspace`, so no extra entitlement is needed, and creates the folder first if no meeting has been saved yet.
- The home-abbreviated path shown below it as small, selectable text.

Deliberately **not** included: a configurable save location (would require a security-scoped bookmark) and a Markdown/text copy — keeping the change minimal and the sandbox untouched.

### Testing

- `xcodebuild build` and `WisprTests` pass (the only failures are the pre-existing `TextCorrectionTokenLeakTests`, which need Apple Intelligence at runtime and are unrelated).
