### PR TITLE
Make a backgrounded meeting visible, stoppable, and never lost on quit

### DIFF
--- a/Sources/WisprApp/Services/MeetingStateManager.swift
+++ b/Sources/WisprApp/Services/MeetingStateManager.swift
@@ -70,6 +70,13 @@ final class MeetingStateManager {
     /// Whether diarization is active for the current session (set at startMeeting).
     private var diarizationActive = false
 
+    /// Guards against a second save while `stopMeeting()` is suspended.
+    ///
+    /// `stopMeeting()` awaits before it flips `meetingState` to `.idle`, so a quit
+    /// during that window would let `finalizeForTermination()` see a still-recording
+    /// session and write a second file.
+    private var isStopping = false
+
     /// Guards against re-entrant `startMeeting()` while capture is being set up
     /// (the window between the first `await` and `meetingState = .recording`).
     private var isStarting = false
@@ -153,7 +160,9 @@ final class MeetingStateManager {
 
     /// Stops the meeting and finalizes the transcript.
     func stopMeeting() async {
-        guard meetingState == .recording else { return }
+        guard meetingState == .recording, !isStopping else { return }
+        isStopping = true
+        defer { isStopping = false }
 
         Log.stateManager.debug("MeetingStateManager — stopping meeting")
 
@@ -176,6 +185,33 @@ final class MeetingStateManager {
         meetingState = .idle
         micLevel = 0
         systemLevel = 0
+    }
+
+    /// Persists an in-progress meeting synchronously, for use on app termination.
+    ///
+    /// `stopMeeting()` cannot be used from `applicationWillTerminate` because it
+    /// is `async` and the app is torn down before the suspension resumes. This
+    /// writes the transcript first and only then cancels the task group, so a
+    /// meeting left running in the background — the window closed while
+    /// recording continues — is never silently lost.
+    ///
+    /// Saving is silent by design: no prompt, no UI. Empty transcripts are
+    /// skipped by `TranscriptStore.save`.
+    func finalizeForTermination() {
+        // `isStopping` means stopMeeting() is mid-flight and will save itself; it
+        // has not yet flipped `meetingState`, so the state check alone would let
+        // both write a file.
+        guard meetingState == .recording, !isStopping else { return }
+
+        let entryCount = transcript.entries.count
+        Log.stateManager.debug(
+            "MeetingStateManager — finalizing in-progress meeting on termination (\(entryCount) entries)"
+        )
+        TranscriptStore.save(transcript)
+
+        recordingTask?.cancel()
+        recordingTask = nil
+        meetingState = .idle
     }
 
     /// Toggles between recording and stopped states.

--- a/Sources/WisprApp/UI/Meeting/MeetingWindowPanel.swift
+++ b/Sources/WisprApp/UI/Meeting/MeetingWindowPanel.swift
@@ -26,6 +26,25 @@ final class MeetingWindowPanel: NSObject, NSWindowDelegate {
     /// Whether the panel is currently visible.
     private(set) var isVisible = false
 
+    /// Whether the panel has been shown at least once this launch. Guards the
+    /// default corner placement so reopening never overrides a position the user
+    /// chose themselves.
+    private var hasBeenShown = false
+
+    /// Key under which AppKit autosaves this window's frame.
+    private static let frameAutosaveName = "MeetingTranscriptionWindow"
+
+    /// Whether AppKit has a stored frame for this window.
+    ///
+    /// Assigning `setFrameAutosaveName` restores a saved frame over the
+    /// `contentRect` passed at construction, so the default corner placement must
+    /// only be applied when nothing was stored. Checked explicitly rather than
+    /// inferred from the frame, since a freshly-created window's origin is not
+    /// guaranteed to be exactly `.zero`.
+    private static var hasAutosavedFrame: Bool {
+        UserDefaults.standard.object(forKey: "NSWindow Frame \(frameAutosaveName)") != nil
+    }
+
     // MARK: - Initialization
 
     init(
@@ -40,15 +59,30 @@ final class MeetingWindowPanel: NSObject, NSWindowDelegate {
 
     // MARK: - Panel Lifecycle
 
-    /// Shows the meeting window.
+    /// Shows the meeting window, or brings it to the front if already open.
+    ///
+    /// Being already visible is not a no-op: the panel can be buried behind a
+    /// fullscreen application, so a menu click must still raise it. This mirrors
+    /// the already-visible handling in `MenuBarController.openSettings()`.
     func show() {
         if panel == nil {
             createPanel()
         }
 
-        guard let panel, !isVisible else { return }
+        guard let panel else { return }
 
-        positionPanel(panel)
+        if isVisible {
+            panel.makeKeyAndOrderFront(nil)
+            panel.orderFrontRegardless()
+            return
+        }
+
+        // Place the panel only on first show; afterwards the autosaved frame set
+        // in createPanel() restores the user's own position and size.
+        if !hasBeenShown {
+            positionPanel(panel)
+            hasBeenShown = true
+        }
         panel.makeKeyAndOrderFront(nil)
         panel.orderFrontRegardless()
         isVisible = true
@@ -87,9 +121,14 @@ final class MeetingWindowPanel: NSObject, NSWindowDelegate {
         panel.hidesOnDeactivate = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.contentView = hostingView
-        panel.minSize = NSSize(width: 320, height: 300)
+        // Match the content's own declared minimum (MeetingTranscriptView uses
+        // .frame(minWidth: 360, minHeight: 400)); a smaller minSize let the window
+        // be dragged below its content size, which clipped the transcript.
+        panel.minSize = NSSize(width: 360, height: 400)
         panel.isReleasedWhenClosed = false
         panel.delegate = self
+        // Persist position and size across close/reopen and across launches.
+        panel.setFrameAutosaveName(Self.frameAutosaveName)
 
         self.panel = panel
     }
@@ -106,8 +145,10 @@ final class MeetingWindowPanel: NSObject, NSWindowDelegate {
 
     // MARK: - Positioning
 
+    /// Places the panel in the bottom-right corner, for the first launch only.
     private func positionPanel(_ panel: NSPanel) {
-        guard let screen = NSScreen.main else { return }
+        // A restored autosaved frame already carries the user's own placement.
+        guard !Self.hasAutosavedFrame, let screen = NSScreen.main else { return }
         let screenFrame = screen.visibleFrame
         let panelSize = panel.frame.size
 

--- a/Sources/WisprApp/UI/MenuBarController.swift
+++ b/Sources/WisprApp/UI/MenuBarController.swift
@@ -94,6 +94,8 @@ final class MenuBarController {
     // MARK: - Menu Items (retained for dynamic updates)
 
     private let recordingMenuItem = NSMenuItem()
+    private let meetingMenuItem = NSMenuItem()
+    private let stopMeetingMenuItem = NSMenuItem()
     private let languageMenuItem = NSMenuItem()
     private let languageSubmenu = NSMenu()
     private let updateMenuItem = NSMenuItem()
@@ -180,16 +182,9 @@ final class MenuBarController {
         menu.addItem(recordingMenuItem)
 
         // Meeting Mode
-        let meetingItem = NSMenuItem(
-            title: "Meeting Transcription…",
-            action: #selector(MenuBarActionHandler.toggleMeetingMode(_:)),
-            keyEquivalent: ""
-        )
-        meetingItem.image = NSImage(
-            systemSymbolName: "person.2.wave.2",
-            accessibilityDescription: "Meeting Transcription"
-        )
-        menu.addItem(meetingItem)
+        updateMeetingMenuItem()
+        menu.addItem(meetingMenuItem)
+        menu.addItem(stopMeetingMenuItem)
 
         menu.addItem(NSMenuItem.separator())
 
@@ -305,6 +300,35 @@ final class MenuBarController {
 
         // Disable during processing
         recordingMenuItem.isEnabled = stateManager.appState != .processing
+    }
+
+    /// Updates the meeting menu items to reflect whether a meeting is recording.
+    ///
+    /// A meeting keeps running with its window closed, so the menu is the only
+    /// place the user can tell it is live — and the only way to stop it without
+    /// reopening the window.
+    private func updateMeetingMenuItem() {
+        let isMeetingRecording = meetingStateManager.meetingState == .recording
+
+        meetingMenuItem.title = isMeetingRecording
+            ? "Meeting Transcription — \(meetingStateManager.elapsedTime)"
+            : "Meeting Transcription…"
+        meetingMenuItem.action = #selector(MenuBarActionHandler.toggleMeetingMode(_:))
+        meetingMenuItem.target = MenuBarActionHandler.shared
+        meetingMenuItem.image = NSImage(
+            systemSymbolName: isMeetingRecording ? "person.2.wave.2.fill" : "person.2.wave.2",
+            accessibilityDescription: isMeetingRecording
+                ? "Meeting transcription in progress" : "Meeting Transcription"
+        )
+
+        stopMeetingMenuItem.title = "Stop Meeting"
+        stopMeetingMenuItem.action = #selector(MenuBarActionHandler.stopMeeting(_:))
+        stopMeetingMenuItem.target = MenuBarActionHandler.shared
+        stopMeetingMenuItem.image = NSImage(
+            systemSymbolName: SFSymbols.stopFill,
+            accessibilityDescription: "Stop Meeting"
+        )
+        stopMeetingMenuItem.isHidden = !isMeetingRecording
     }
 
     // MARK: - CLI Install Menu Item
@@ -490,6 +514,7 @@ final class MenuBarController {
 
                 self.updateIcon(for: currentState)
                 self.updateRecordingMenuItem()
+                self.updateMeetingMenuItem()
                 self.refreshUpdateMenuItem()
                 self.languageMenuItem.title = self.languageDisplayTitle()
                 self.buildLanguageSubmenu()
@@ -502,6 +527,10 @@ final class MenuBarController {
                         _ = self.settingsStore.hotkeyKeyCode
                         _ = self.settingsStore.hotkeyModifiers
                         _ = self.updateChecker.availableUpdate
+                        // A meeting can run with its window closed; track it so the
+                        // menu reflects the live session and offers "Stop Meeting".
+                        _ = self.meetingStateManager.meetingState
+                        _ = self.meetingStateManager.elapsedTime
                     } onChange: {
                         continuation.resume()
                     }
@@ -683,6 +712,11 @@ final class MenuBarController {
     func toggleMeetingMode() {
         meetingStateManager.isWindowVisible = true
     }
+
+    /// Stops an in-progress meeting from the menu, without needing the window.
+    func stopMeeting() {
+        Task { await meetingStateManager.stopMeeting() }
+    }
 }
 
 // MARK: - Menu Open Delegate
@@ -751,6 +785,11 @@ final class MenuBarActionHandler: NSObject {
     @MainActor
     @objc func toggleMeetingMode(_ sender: NSMenuItem) {
         menuBarController?.toggleMeetingMode()
+    }
+
+    @MainActor
+    @objc func stopMeeting(_ sender: NSMenuItem) {
+        menuBarController?.stopMeeting()
     }
 
     @MainActor

--- a/Sources/WisprApp/wisprApp.swift
+++ b/Sources/WisprApp/wisprApp.swift
@@ -349,7 +349,9 @@ final class WisprAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate 
         permissionMonitoringTask?.cancel()
         updateCheckTask?.cancel()
 
-        // Stop any active meeting session (synchronous — cascades via task group)
+        // Persist any in-progress meeting BEFORE cancelling its task group, so a
+        // session left running with the window closed is not lost on quit.
+        meetingStateManager?.finalizeForTermination()
         meetingStateManager?.cancelRecording()
 
         // Stop meeting detection monitoring.

--- a/wisprTests/MeetingStateManagerTests.swift
+++ b/wisprTests/MeetingStateManagerTests.swift
@@ -249,6 +249,55 @@ struct MeetingStateManagerTests {
         #expect(manager.elapsedTime == "0:00")
     }
 
+    // MARK: - Termination Safety
+
+    @Test("finalizeForTermination is a no-op when idle")
+    func testFinalizeForTerminationWhenIdle() {
+        let manager = createTestMeetingStateManager()
+        #expect(manager.meetingState == .idle)
+
+        // Must not throw, must not change state, and must not write a file for a
+        // session that was never recording.
+        manager.finalizeForTermination()
+
+        #expect(manager.meetingState == .idle)
+    }
+
+    @Test("finalizeForTermination persists an in-progress transcript and clears state")
+    func testFinalizeForTerminationSavesInProgress() throws {
+        let manager = createTestMeetingStateManager()
+
+        // Simulate a meeting that is recording with content, as happens when the
+        // user closes the window and keeps talking before quitting the app.
+        manager.meetingState = .recording
+        manager.transcript.entries.append(
+            MeetingTranscriptEntry(speaker: .you, text: "quitting mid meeting")
+        )
+
+        let before = existingTranscriptFilenames()
+        manager.finalizeForTermination()
+        let after = existingTranscriptFilenames()
+
+        // The session is no longer considered live...
+        #expect(manager.meetingState == .idle)
+        // ...and exactly one new transcript landed on disk.
+        let created = after.subtracting(before)
+        #expect(created.count == 1)
+
+        // Clean up the file this test wrote so repeated runs stay hermetic.
+        for name in created {
+            try? FileManager.default.removeItem(
+                at: TranscriptStore.directory.appendingPathComponent(name))
+        }
+    }
+
+    /// Snapshot of the transcripts directory, used to detect files written by a test.
+    private func existingTranscriptFilenames() -> Set<String> {
+        let contents = try? FileManager.default.contentsOfDirectory(
+            atPath: TranscriptStore.directory.path)
+        return Set(contents ?? [])
+    }
+
     // MARK: - Start Meeting
 
     @Test("startMeeting fails without mic permission and sets error state", .disabled("Timing-sensitive: auto-dismiss timer causes flakiness"))


### PR DESCRIPTION
Closing the meeting window does not stop the meeting — `windowWillClose` only clears the visibility flags, and recording continues. That is the right behaviour for a menu bar app, but nothing else in the app acknowledged it, which left three problems.

### The transcript was lost on quit

`applicationWillTerminate` calls `cancelRecording()`, which cancels the task group and saves nothing. `TranscriptStore.save` ran only from `stopMeeting()`. So: start a meeting, close the window, keep talking, quit from the menu — the entire session is destroyed with no warning.

`finalizeForTermination()` now writes the transcript before cancelling. It is synchronous because `stopMeeting()` is `async` and the app is torn down before the suspension would resume. Saving is silent, and empty transcripts are still skipped.

### A running meeting was invisible

`startObservingState()` tracked `stateManager.appState` but not `meetingState`, so a recording meeting with the window closed produced no signal at all: the menu title was unchanged, and there was no way to stop it without reopening the window.

The menu item now shows the elapsed time with a filled icon, and a "Stop Meeting" item appears while recording.

### Reopening from the menu could be a dead click

`show()` began with `guard !isVisible else { return }`. Clicking the menu item while the window was open but buried behind a fullscreen app therefore did nothing. It now brings the panel to the front, matching the already-visible handling in `openSettings()`.

### Two window annoyances

`positionPanel` ran on every show, snapping the window back to the bottom-right corner and discarding the user's own placement. It now runs only on first show, with `setFrameAutosaveName` persisting position and size across launches.

`minSize` was 320x300 while the content declares `.frame(minWidth: 360, minHeight: 400)`, so the window could be dragged smaller than its content and clip the transcript.

### Testing

`swift build` and the full `swift test` suite pass (536 tests). `xcodebuild` build passes. Two new tests cover `finalizeForTermination`: the no-op when idle, and the persistence path, which compares the transcripts directory before and after to assert a file is actually written, then cleans up after itself.

Verified manually: close the window mid-meeting, speak, quit from the menu, and the JSON is on disk with the speech that arrived after the window was closed.

### Note

No behaviour changes when the window is open and the app is quit normally through `stopMeeting()` — that path already saved.
