### PR TITLE
feat(meeting): browse, name, and manage saved transcripts

### DIFF
--- a/Sources/WisprApp/Models/MeetingTranscript.swift
+++ b/Sources/WisprApp/Models/MeetingTranscript.swift
@@ -31,6 +31,20 @@ enum MeetingSpeaker: Sendable, Equatable, Hashable, Codable {
         if case .others = self { return true }
         return false
     }
+
+    /// Stable key used to look up a user-assigned name for this speaker.
+    ///
+    /// Diarization indices are the only handle we have on a remote person, so a
+    /// name is stored against the index rather than against individual entries.
+    /// The unresolved `.others(nil)` track gets its own key: it cannot be told
+    /// apart per person, but naming it is still useful (for example "Room").
+    var nameKey: String {
+        switch self {
+        case .you: return "you"
+        case .others(.none): return "others"
+        case .others(.some(let index)): return "speaker-\(index)"
+        }
+    }
 }
 
 /// A single timestamped entry in a meeting transcript.
@@ -53,8 +67,77 @@ struct MeetingTranscript: Sendable, Equatable, Codable {
     var entries: [MeetingTranscriptEntry] = []
     let startTime: Date
 
-    init(startTime: Date = Date()) {
+    /// User-supplied name for the session ("Sprint review" rather than a date).
+    /// `nil` means it is shown by its date. Optional so that transcripts written
+    /// before naming existed still decode.
+    var title: String?
+
+    /// Names the user has given the speakers, keyed by `MeetingSpeaker.nameKey`.
+    ///
+    /// Most useful after the meeting, which is when you actually know who
+    /// "Speaker 2" was.
+    var speakerNames: [String: String] = [:]
+
+    init(startTime: Date = Date(), title: String? = nil) {
         self.startTime = startTime
+        self.title = title
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case entries, startTime, title, speakerNames
+    }
+
+    /// Decoded explicitly rather than by synthesis: the synthesized initializer
+    /// requires every key to be present and does NOT fall back to a property's
+    /// default, so adding `speakerNames` would otherwise fail to decode every
+    /// transcript written before this existed.
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        entries = try container.decode([MeetingTranscriptEntry].self, forKey: .entries)
+        startTime = try container.decode(Date.self, forKey: .startTime)
+        title = try container.decodeIfPresent(String.self, forKey: .title)
+        speakerNames =
+            try container.decodeIfPresent([String: String].self, forKey: .speakerNames) ?? [:]
+    }
+
+    // MARK: - Speaker Names
+
+    /// The label to show for `speaker`: the user's name for them when set,
+    /// otherwise the generated "You" / "Speaker 2" / "Others".
+    func displayName(for speaker: MeetingSpeaker) -> String {
+        if let name = speakerNames[speaker.nameKey], !name.isEmpty { return name }
+        return speaker.displayName
+    }
+
+    /// Names a speaker, or clears the name when passed `nil` or whitespace.
+    mutating func setName(_ name: String?, for speaker: MeetingSpeaker) {
+        let cleaned = name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let cleaned, !cleaned.isEmpty {
+            speakerNames[speaker.nameKey] = cleaned
+        } else {
+            speakerNames.removeValue(forKey: speaker.nameKey)
+        }
+    }
+
+    /// Distinct speakers appearing in the transcript, ordered for display: the
+    /// local speaker first, then resolved remote speakers by index, then the
+    /// unresolved track.
+    var presentSpeakers: [MeetingSpeaker] {
+        var seen: [MeetingSpeaker] = []
+        for entry in entries where !seen.contains(entry.speaker) {
+            seen.append(entry.speaker)
+        }
+
+        return seen.sorted { lhs, rhs in
+            func rank(_ speaker: MeetingSpeaker) -> Int {
+                switch speaker {
+                case .you: return 0
+                case .others(.some(let index)): return 1 + index
+                case .others(.none): return Int.max
+                }
+            }
+            return rank(lhs) < rank(rhs)
+        }
     }
 
     // MARK: - Echo Suppression
@@ -205,10 +288,13 @@ struct MeetingTranscript: Sendable, Equatable, Codable {
     }
 
     /// Formats the entire transcript as plain text for export.
+    ///
+    /// Uses assigned speaker names, so a copied or exported transcript reads the
+    /// same as what is on screen.
     func asPlainText() -> String {
         entries.map { entry in
             let time = Self.formatTime(entry.timestamp)
-            return "[\(time)] \(entry.speaker.displayName): \(entry.text)"
+            return "[\(time)] \(displayName(for: entry.speaker)): \(entry.text)"
         }.joined(separator: "\n")
     }
 
@@ -222,6 +308,30 @@ struct MeetingTranscript: Sendable, Equatable, Codable {
         let total = Int(duration)
         let minutes = total / 60
         let seconds = total % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    /// Wall-clock span the transcript actually covers, from its first timestamp
+    /// to its last.
+    ///
+    /// `duration` is measured against *now*, which is right while recording but
+    /// meaningless for a session loaded from disk, where it would grow forever.
+    /// Saved sessions are described with this instead.
+    var recordedSpan: TimeInterval {
+        guard let last = entries.last?.timestamp else { return 0 }
+        return max(0, last.timeIntervalSince(startTime))
+    }
+
+    /// `recordedSpan` as "h:mm:ss", hours omitted when zero. Unlike
+    /// `formattedDuration` this does not render a two-hour meeting as "140:12".
+    var formattedRecordedSpan: String {
+        let total = Int(recordedSpan)
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        let seconds = total % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
         return String(format: "%d:%02d", minutes, seconds)
     }
 }

--- a/Sources/WisprApp/Services/MeetingHistoryStore.swift
+++ b/Sources/WisprApp/Services/MeetingHistoryStore.swift
@@ -1,0 +1,148 @@
+//
+//  MeetingHistoryStore.swift
+//  wispr
+//
+//  Observable state for the meeting history sidebar: which sessions exist,
+//  which one is on screen, and the rename/delete operations on them.
+//
+
+import Foundation
+import Observation
+import os
+
+/// What the transcript pane is currently showing.
+enum TranscriptSelection: Hashable, Sendable {
+    /// The session being recorded now, or the last one recorded this launch.
+    case live
+    /// A session loaded from disk.
+    case archived(URL)
+}
+
+/// Owns the list of saved transcripts and the current selection.
+///
+/// Kept separate from `MeetingStateManager` so that browsing history never
+/// touches recording state: opening an old session must not be able to disturb
+/// a meeting that is running.
+@MainActor
+@Observable
+final class MeetingHistoryStore {
+
+    // MARK: - Published State
+
+    /// Saved sessions, newest first.
+    private(set) var summaries: [TranscriptSummary] = []
+
+    /// Which session the transcript pane shows.
+    private(set) var selection: TranscriptSelection = .live
+
+    /// The decoded transcript for an archived selection; `nil` when showing live.
+    private(set) var loadedTranscript: MeetingTranscript?
+
+    /// Surfaced in the sidebar when an operation fails, rather than failing silently.
+    var errorMessage: String?
+
+    /// Whether an archived session is on screen, as opposed to the live one.
+    var isShowingArchived: Bool {
+        if case .archived = selection { return true }
+        return false
+    }
+
+    /// Summary for the current archived selection, if any.
+    var selectedSummary: TranscriptSummary? {
+        guard case .archived(let url) = selection else { return nil }
+        return summaries.first { $0.url == url }
+    }
+
+    // MARK: - Loading
+
+    /// Re-reads the transcripts directory.
+    ///
+    /// If the open archived session has disappeared underneath us (deleted in
+    /// Finder, say), the selection falls back to live rather than leaving a
+    /// stale transcript on screen.
+    func refresh() {
+        summaries = TranscriptStore.list()
+
+        if case .archived(let url) = selection,
+            !summaries.contains(where: { $0.url == url })
+        {
+            showLive()
+        }
+    }
+
+    // MARK: - Selection
+
+    /// Shows the live session.
+    func showLive() {
+        selection = .live
+        loadedTranscript = nil
+    }
+
+    /// Loads and shows a saved session, staying put if it cannot be read.
+    func show(_ summary: TranscriptSummary) {
+        guard let transcript = TranscriptStore.load(summary.url) else {
+            errorMessage = "Could not open \(summary.displayName)."
+            return
+        }
+        loadedTranscript = transcript
+        selection = .archived(summary.url)
+        errorMessage = nil
+    }
+
+    // MARK: - Mutating
+
+    /// Names a session, or reverts it to its date when passed `nil`.
+    func rename(_ summary: TranscriptSummary, to title: String?) {
+        guard let newURL = TranscriptStore.rename(summary.url, to: title) else {
+            errorMessage = "Could not rename \(summary.displayName)."
+            return
+        }
+
+        let wasSelected = (selection == .archived(summary.url))
+        refresh()
+
+        // The URL is the row's identity and changes with the slug, so an open
+        // session is re-pointed at its new file instead of closing.
+        if wasSelected, let moved = summaries.first(where: { $0.url == newURL }) {
+            show(moved)
+        }
+        errorMessage = nil
+    }
+
+    /// Deletes a session. Irreversible: wispr keeps no audio to re-transcribe
+    /// from, so the caller is expected to have confirmed with the user.
+    func delete(_ summary: TranscriptSummary) {
+        guard TranscriptStore.delete(summary.url) else {
+            errorMessage = "Could not delete \(summary.displayName)."
+            return
+        }
+
+        if selection == .archived(summary.url) {
+            showLive()
+        }
+        refresh()
+        errorMessage = nil
+    }
+
+    /// Names a speaker in the session currently on screen, writing it straight
+    /// back to that session's file.
+    ///
+    /// Only meaningful for an archived session: the live transcript is owned by
+    /// `MeetingStateManager` and has no file to update until it is saved, which
+    /// is also when the user actually knows who was who.
+    func renameSpeaker(_ speaker: MeetingSpeaker, to name: String?) {
+        guard case .archived(let url) = selection, var transcript = loadedTranscript else {
+            return
+        }
+
+        transcript.setName(name, for: speaker)
+
+        guard TranscriptStore.save(transcript, to: url) else {
+            errorMessage = "Could not save the speaker name."
+            return
+        }
+
+        loadedTranscript = transcript
+        errorMessage = nil
+    }
+}

--- a/Sources/WisprApp/Services/MeetingStateManager.swift
+++ b/Sources/WisprApp/Services/MeetingStateManager.swift
@@ -56,6 +56,10 @@ final class MeetingStateManager {
     /// Timer display string.
     var elapsedTime: String = "0:00"
 
+    /// File the most recent session was saved to. The history sidebar watches
+    /// this so a finished meeting appears without the user refreshing anything.
+    private(set) var lastSavedTranscriptURL: URL?
+
     // MARK: - Dependencies
 
     private let meetingAudioEngine: MeetingAudioEngine
@@ -171,7 +175,7 @@ final class MeetingStateManager {
 
         // Persist the completed session to disk before it can be overwritten
         // by a subsequent startMeeting() (which resets `transcript`).
-        TranscriptStore.save(transcript)
+        lastSavedTranscriptURL = TranscriptStore.save(transcript)
 
         meetingState = .idle
         micLevel = 0
@@ -193,9 +197,27 @@ final class MeetingStateManager {
 
     /// Copies the transcript to the clipboard.
     func copyTranscript() {
+        copy(transcript)
+    }
+
+    /// Copies an arbitrary transcript, so the history view can copy an archived
+    /// session rather than whatever is live.
+    func copy(_ transcript: MeetingTranscript) {
         let text = transcript.asPlainText()
         guard !text.isEmpty else { return }
         ClipboardService.copy(text)
+    }
+
+    /// Persists the transcript, then cancels recording.
+    ///
+    /// Called from `applicationWillTerminate`. `stopMeeting()` cannot be used
+    /// there: it is `async`, and the process is torn down before the suspension
+    /// would resume, so the session has to be written inline first. Without
+    /// this, closing the window mid-meeting and quitting from the menu destroys
+    /// the whole session, since `cancelRecording()` saves nothing.
+    func finalizeForTermination() {
+        lastSavedTranscriptURL = TranscriptStore.save(transcript)
+        cancelRecording()
     }
 
     // MARK: - Transcription

--- a/Sources/WisprApp/Services/TranscriptStore.swift
+++ b/Sources/WisprApp/Services/TranscriptStore.swift
@@ -21,11 +21,21 @@ enum TranscriptStore {
     /// Directory where transcript JSON files are stored.
     static var directory: URL { ModelPaths.transcripts }
 
+    /// Every saved session's filename starts with this, so `list()` can tell
+    /// them apart from anything else that ends up in the directory.
+    static let filePrefix = "meeting-"
+
     private static let encoder: JSONEncoder = {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
         encoder.dateEncodingStrategy = .iso8601
         return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
     }()
 
     /// File-name timestamp formatter (e.g. `2026-06-22_14-30-05`).
@@ -72,4 +82,212 @@ enum TranscriptStore {
             return nil
         }
     }
+
+    /// Overwrites an existing transcript file in place.
+    ///
+    /// - Returns: `true` if the file was written.
+    @discardableResult
+    static func save(_ transcript: MeetingTranscript, to url: URL) -> Bool {
+        do {
+            try FileManager.default.createDirectory(
+                at: directory, withIntermediateDirectories: true)
+            let data = try encoder.encode(transcript)
+            try data.write(to: url, options: .atomic)
+            return true
+        } catch {
+            Log.stateManager.error(
+                "TranscriptStore — failed to write \(url.lastPathComponent): \(error.localizedDescription)"
+            )
+            return false
+        }
+    }
+
+    // MARK: - Reading
+
+    /// Every saved session, newest first.
+    ///
+    /// A file that cannot be decoded is skipped and logged rather than aborting
+    /// the listing, so one damaged file does not hide the rest of the history.
+    static func list() -> [TranscriptSummary] {
+        let fileManager = FileManager.default
+
+        guard
+            let urls = try? fileManager.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            )
+        else {
+            // No directory yet simply means nothing has been recorded.
+            return []
+        }
+
+        let candidates = urls.filter {
+            $0.pathExtension == "json" && $0.lastPathComponent.hasPrefix(filePrefix)
+        }
+
+        var summaries: [TranscriptSummary] = []
+        for url in candidates {
+            guard let transcript = load(url) else { continue }
+            summaries.append(
+                TranscriptSummary(
+                    url: url,
+                    startTime: transcript.startTime,
+                    title: transcript.title,
+                    entryCount: transcript.entries.count,
+                    span: transcript.recordedSpan,
+                    preview: transcript.entries.first?.text
+                        .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                )
+            )
+        }
+
+        return summaries.sorted { $0.startTime > $1.startTime }
+    }
+
+    /// Decodes a single saved session.
+    static func load(_ url: URL) -> MeetingTranscript? {
+        do {
+            let data = try Data(contentsOf: url)
+            return try decoder.decode(MeetingTranscript.self, from: data)
+        } catch {
+            Log.stateManager.warning(
+                "TranscriptStore — could not read \(url.lastPathComponent): \(error.localizedDescription)"
+            )
+            return nil
+        }
+    }
+
+    // MARK: - Mutating
+
+    /// Deletes a saved session.
+    ///
+    /// wispr keeps no audio, so a deleted transcript cannot be recreated: callers
+    /// are expected to have confirmed with the user first.
+    @discardableResult
+    static func delete(_ url: URL) -> Bool {
+        do {
+            try FileManager.default.removeItem(at: url)
+            return true
+        } catch {
+            Log.stateManager.error(
+                "TranscriptStore — failed to delete \(url.lastPathComponent): \(error.localizedDescription)"
+            )
+            return false
+        }
+    }
+
+    /// Names a session, or clears the name when passed `nil` or whitespace.
+    ///
+    /// The title is stored inside the JSON; the filename keeps its `meeting-` +
+    /// timestamp form and gains a slug of the title, so `list()` still finds the
+    /// file and the timestamp stays authoritative. Nothing is ever read back out
+    /// of the filename, so the two cannot drift into disagreement.
+    ///
+    /// - Returns: The file's URL, which changes when the slug changes.
+    @discardableResult
+    static func rename(_ url: URL, to title: String?) -> URL? {
+        guard var transcript = load(url) else { return nil }
+
+        let cleaned = title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        transcript.title = (cleaned?.isEmpty ?? true) ? nil : cleaned
+
+        // Write the title first: if the move then fails, the rename is still
+        // recorded rather than lost.
+        guard save(transcript, to: url) else { return nil }
+
+        let target = uniqueURL(for: transcript, excluding: url)
+        guard target != url else { return url }
+
+        do {
+            try FileManager.default.moveItem(at: url, to: target)
+            return target
+        } catch {
+            Log.stateManager.error(
+                "TranscriptStore — renamed in place but could not move file: \(error.localizedDescription)"
+            )
+            // The title did land, so report the original URL rather than failing.
+            return url
+        }
+    }
+
+    // MARK: - Naming
+
+    /// `meeting-<timestamp>.json`, with a slug of the title appended when there
+    /// is one, and a numeric suffix if that name is already taken.
+    private static func uniqueURL(
+        for transcript: MeetingTranscript,
+        excluding current: URL? = nil
+    ) -> URL {
+        var base = filePrefix + filenameFormatter.string(from: transcript.startTime)
+        if let slug = slug(from: transcript.title) {
+            base += "-" + slug
+        }
+
+        var candidate = directory.appendingPathComponent(base + ".json", isDirectory: false)
+        var counter = 2
+
+        while FileManager.default.fileExists(atPath: candidate.path), candidate != current {
+            candidate = directory.appendingPathComponent(
+                "\(base)-\(counter).json", isDirectory: false)
+            counter += 1
+        }
+
+        return candidate
+    }
+
+    /// Lowercased, hyphen-separated and length-capped, so the filename stays
+    /// sane regardless of what the user typed.
+    private static func slug(from title: String?) -> String? {
+        guard let title, !title.isEmpty else { return nil }
+
+        let mapped = title.lowercased().map { character -> Character in
+            character.isLetter || character.isNumber ? character : "-"
+        }
+        let collapsed = String(mapped)
+            .split(separator: "-", omittingEmptySubsequences: true)
+            .joined(separator: "-")
+
+        guard !collapsed.isEmpty else { return nil }
+        return String(collapsed.prefix(40))
+    }
+}
+
+/// A lightweight description of a saved session, so the history list can be
+/// rendered without holding every full transcript in memory.
+struct TranscriptSummary: Identifiable, Sendable, Equatable {
+    let url: URL
+    let startTime: Date
+    let title: String?
+    let entryCount: Int
+    let span: TimeInterval
+    /// Opening words of the session, for a one-line hint under the title.
+    let preview: String
+
+    var id: URL { url }
+
+    /// The user's name for the session, or its date when unnamed.
+    var displayName: String {
+        if let title, !title.isEmpty { return title }
+        return Self.dateFormatter.string(from: startTime)
+    }
+
+    /// `span` as "h:mm:ss", hours omitted when zero.
+    var formattedSpan: String {
+        let total = Int(span)
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        let seconds = total % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
 }

--- a/Sources/WisprApp/UI/Meeting/MeetingHistorySidebar.swift
+++ b/Sources/WisprApp/UI/Meeting/MeetingHistorySidebar.swift
@@ -1,0 +1,191 @@
+//
+//  MeetingHistorySidebar.swift
+//  wispr
+//
+//  Sidebar listing past meeting transcripts, with the live session pinned on top.
+//
+
+import AppKit
+import SwiftUI
+
+/// Lists saved meeting transcripts and lets one be opened, renamed, or deleted.
+///
+/// Deliberately a plain column rather than a `NavigationSplitView` sidebar. The
+/// split view supplies its own collapse button, and that button moves between
+/// the leading and trailing edge of the title bar depending on whether the
+/// sidebar is open; owning the visibility state keeps the toggle in one place.
+struct MeetingHistorySidebar: View {
+    @Environment(MeetingStateManager.self) private var meetingState: MeetingStateManager
+    @Environment(UIThemeEngine.self) private var theme: UIThemeEngine
+
+    let history: MeetingHistoryStore
+
+    /// Session awaiting delete confirmation. Deletion is irreversible, so it is
+    /// always confirmed.
+    @State private var pendingDeletion: TranscriptSummary?
+
+    /// Session being retitled, and the in-flight text.
+    @State private var editingURL: URL?
+    @State private var editingTitle = ""
+
+    /// Focuses the rename field as it appears, so a name can be typed straight
+    /// away instead of having to click into the visible box first.
+    @FocusState private var titleFieldFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            List {
+                Section {
+                    liveRow
+                }
+
+                if !history.summaries.isEmpty {
+                    Section("History") {
+                        ForEach(history.summaries) { summary in
+                            historyRow(summary)
+                        }
+                    }
+                }
+            }
+            .listStyle(.sidebar)
+
+            if let message = history.errorMessage {
+                Text(message)
+                    .font(.caption2)
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .frame(minWidth: 190, idealWidth: 210, maxWidth: 280)
+        .task { history.refresh() }
+        .confirmationDialog(
+            "Delete this transcript?",
+            isPresented: deletionPresented,
+            presenting: pendingDeletion
+        ) { summary in
+            Button("Delete", role: .destructive) {
+                history.delete(summary)
+                pendingDeletion = nil
+            }
+            Button("Cancel", role: .cancel) { pendingDeletion = nil }
+        } message: { _ in
+            Text("wispr keeps no audio, so the transcript cannot be recreated.")
+        }
+    }
+
+    // MARK: - Live Row
+
+    private var liveRow: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(meetingState.meetingState == .recording ? Color.red : Color.secondary)
+                    .frame(width: 7, height: 7)
+
+                Text("Current Session")
+                    .font(.callout.weight(.medium))
+            }
+
+            Text(entryCountLabel(meetingState.transcript.entries.count))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
+        .onTapGesture { history.showLive() }
+        .listRowBackground(rowBackground(isSelected: !history.isShowingArchived))
+    }
+
+    // MARK: - History Row
+
+    @ViewBuilder
+    private func historyRow(_ summary: TranscriptSummary) -> some View {
+        let isSelected = history.selection == .archived(summary.url)
+
+        VStack(alignment: .leading, spacing: 2) {
+            if editingURL == summary.url {
+                TextField("Session name", text: $editingTitle)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.caption)
+                    .focused($titleFieldFocused)
+                    .onAppear { titleFieldFocused = true }
+                    .onSubmit { commitRename(summary) }
+                    .onExitCommand { cancelRename() }
+            } else {
+                Text(summary.displayName)
+                    .font(.callout.weight(.medium))
+                    .lineLimit(1)
+            }
+
+            Text("\(summary.formattedSpan) · \(entryCountLabel(summary.entryCount))")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+
+            if !summary.preview.isEmpty {
+                Text(summary.preview)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 2)
+        .contentShape(Rectangle())
+        .onTapGesture { history.show(summary) }
+        .listRowBackground(rowBackground(isSelected: isSelected))
+        .contextMenu {
+            Button("Rename…") { beginRename(summary) }
+            if summary.title != nil {
+                Button("Use Date as Name") { history.rename(summary, to: nil) }
+            }
+            Divider()
+            Button("Show in Finder") {
+                NSWorkspace.shared.activateFileViewerSelecting([summary.url])
+            }
+            Divider()
+            Button("Delete…", role: .destructive) { pendingDeletion = summary }
+        }
+    }
+
+    // MARK: - Rename
+
+    private func beginRename(_ summary: TranscriptSummary) {
+        editingTitle = summary.title ?? ""
+        editingURL = summary.url
+    }
+
+    private func commitRename(_ summary: TranscriptSummary) {
+        history.rename(summary, to: editingTitle)
+        cancelRename()
+    }
+
+    private func cancelRename() {
+        editingURL = nil
+        editingTitle = ""
+        titleFieldFocused = false
+    }
+
+    // MARK: - Chrome
+
+    private func entryCountLabel(_ count: Int) -> String {
+        count == 1 ? "1 entry" : "\(count) entries"
+    }
+
+    private func rowBackground(isSelected: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .fill(isSelected ? theme.accentColor.opacity(0.18) : Color.clear)
+    }
+
+    /// `confirmationDialog` needs a `Bool` binding; the pending session is the
+    /// real state, so this projects one from it.
+    private var deletionPresented: Binding<Bool> {
+        Binding(
+            get: { pendingDeletion != nil },
+            set: { if !$0 { pendingDeletion = nil } }
+        )
+    }
+}

--- a/Sources/WisprApp/UI/Meeting/MeetingTranscriptView.swift
+++ b/Sources/WisprApp/UI/Meeting/MeetingTranscriptView.swift
@@ -21,42 +21,118 @@ struct MeetingTranscriptView: View {
 
     @State private var isExporting = false
 
+    /// Owns the saved-transcript list. Held here rather than injected because
+    /// nothing outside this window needs it.
+    @State private var history = MeetingHistoryStore()
+
+    /// Whether the history column is shown. Owned locally so the toggle button
+    /// keeps a fixed position.
+    @State private var showHistory = false
+
+    /// Speaker being renamed in the roster, and the in-flight text.
+    @State private var editingSpeaker: MeetingSpeaker?
+    @State private var editingSpeakerName = ""
+
+    /// Focuses the rename field as it appears, so a name can be typed straight
+    /// away instead of having to click into the visible box first.
+    @FocusState private var speakerFieldFocused: Bool
+
+    /// The transcript on screen: the live session, or one loaded from disk.
+    ///
+    /// Deliberately decoupled from `meetingState.transcript` so that opening an
+    /// archived session cannot disturb a recording in progress, and starting a
+    /// meeting cannot wipe an archive the user is reading.
+    private var displayedTranscript: MeetingTranscript {
+        if history.isShowingArchived {
+            return history.loadedTranscript ?? MeetingTranscript()
+        }
+        return meetingState.transcript
+    }
+
+    /// Archived sessions have no live controls and no auto-scroll.
+    private var isArchived: Bool { history.isShowingArchived }
+
     var body: some View {
-        VStack(spacing: 0) {
-            // Header with controls
-            headerBar
-
-            Divider()
-
-            // Transcript area
-            if meetingState.transcript.entries.isEmpty {
-                emptyState
-            } else {
-                transcriptList
+        HStack(spacing: 0) {
+            if showHistory {
+                MeetingHistorySidebar(history: history)
+                Divider()
             }
 
-            Divider()
+            VStack(spacing: 0) {
+                // Header with controls
+                headerBar
 
-            // Footer with export actions
-            footerBar
+                Divider()
+
+                // Speaker names, for a finished session.
+                if isArchived && !displayedTranscript.presentSpeakers.isEmpty {
+                    speakerRoster
+                    Divider()
+                }
+
+                // Transcript area
+                if displayedTranscript.entries.isEmpty {
+                    emptyState
+                } else {
+                    transcriptList
+                }
+
+                Divider()
+
+                // Footer with export actions
+                footerBar
+            }
+            .frame(minWidth: 360, minHeight: 400)
         }
-        .frame(minWidth: 360, minHeight: 400)
         .fileExporter(
             isPresented: $isExporting,
-            document: TranscriptDocument(text: meetingState.transcript.asPlainText()),
+            document: TranscriptDocument(text: displayedTranscript.asPlainText()),
             contentType: .plainText,
-            defaultFilename: "meeting-transcript"
+            defaultFilename: exportFilename
         ) { result in
             if case .failure(let error) = result {
                 Log.stateManager.error("Export failed: \(error.localizedDescription)")
             }
         }
+        // stopMeeting() writes the session to disk; pick it up so it appears in
+        // the history list straight away.
+        .onChange(of: meetingState.lastSavedTranscriptURL) { _, newValue in
+            guard newValue != nil else { return }
+            history.refresh()
+        }
+    }
+
+    /// Archived exports are named after the session, not "meeting-transcript".
+    private var exportFilename: String {
+        guard isArchived, let summary = history.selectedSummary else {
+            return "meeting-transcript"
+        }
+        return summary.url.deletingPathExtension().lastPathComponent
     }
 
     // MARK: - Header
 
     private var headerBar: some View {
         HStack(spacing: 12) {
+            // History toggle. First in the row and never moves, whether the
+            // sidebar is open or closed.
+            Button {
+                showHistory.toggle()
+            } label: {
+                Image(systemName: "sidebar.left")
+                    .font(.body)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(
+                        showHistory ? theme.accentColor.opacity(0.15) : Color.clear
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .help(showHistory ? "Hide transcript history" : "Show transcript history")
+            .accessibilityLabel("Toggle transcript history")
+
             // Record/Stop button
             Button {
                 Task { await meetingState.toggleMeeting() }
@@ -85,8 +161,22 @@ struct MeetingTranscriptView: View {
 
             Spacer()
 
+            // Which archived session is open, and the way back to the live one.
+            if isArchived {
+                if let summary = history.selectedSummary {
+                    Text(summary.displayName)
+                        .font(.callout.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Button("Current Session") { history.showLive() }
+                    .buttonStyle(.link)
+                    .font(.callout)
+            }
+
             // Audio level indicators
-            if meetingState.meetingState == .recording {
+            if meetingState.meetingState == .recording && !isArchived {
                 HStack(spacing: 8) {
                     audioLevelIndicator(label: "You", level: meetingState.micLevel, color: .blue)
                     audioLevelIndicator(
@@ -159,7 +249,7 @@ struct MeetingTranscriptView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 8) {
-                    ForEach(meetingState.transcript.entries) { entry in
+                    ForEach(displayedTranscript.entries) { entry in
                         transcriptRow(entry)
                             .id(entry.id)
                     }
@@ -168,7 +258,10 @@ struct MeetingTranscriptView: View {
                 .padding(.vertical, 8)
             }
             .onChange(of: meetingState.transcript.entries.count) { _, _ in
-                // Auto-scroll to latest entry
+                // Auto-scroll to latest entry. Only while the live session is on
+                // screen: an archived transcript should stay where the user
+                // scrolled it, even if a meeting is recording in the background.
+                guard !isArchived else { return }
                 if let lastEntry = meetingState.transcript.entries.last {
                     withAnimation(.easeOut(duration: 0.2)) {
                         proxy.scrollTo(lastEntry.id, anchor: .bottom)
@@ -187,10 +280,12 @@ struct MeetingTranscriptView: View {
                 .frame(width: 50, alignment: .trailing)
 
             // Speaker badge
-            Text(entry.speaker.displayName)
+            Text(displayedTranscript.displayName(for: entry.speaker))
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(speakerColor(entry.speaker))
-                .frame(width: 56, alignment: .leading)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(width: 84, alignment: .leading)
 
             // Text
             Text(entry.text)
@@ -204,6 +299,77 @@ struct MeetingTranscriptView: View {
 
     private func formatTime(_ date: Date) -> String {
         MeetingTranscript.formatTime(date)
+    }
+
+    // MARK: - Speaker Roster
+
+    /// Lets each speaker in a finished session be given a real name.
+    ///
+    /// Offered only for an archived session: naming is most useful once the
+    /// meeting is over (which is when you know who "Speaker 2" was), and an
+    /// archived session has a file to write the name back to. The live
+    /// transcript has no file until it is saved.
+    private var speakerRoster: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                Text("Speakers")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+
+                ForEach(displayedTranscript.presentSpeakers, id: \.self) { speaker in
+                    if editingSpeaker == speaker {
+                        TextField(speaker.displayName, text: $editingSpeakerName)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.caption)
+                            .frame(width: 120)
+                            .focused($speakerFieldFocused)
+                            .onAppear { speakerFieldFocused = true }
+                            .onSubmit { commitSpeakerRename(speaker) }
+                            .onExitCommand { cancelSpeakerRename() }
+                    } else {
+                        Button {
+                            beginSpeakerRename(speaker)
+                        } label: {
+                            Text(displayedTranscript.displayName(for: speaker))
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(speakerColor(speaker))
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 4)
+                                .background(speakerColor(speaker).opacity(0.12))
+                                .clipShape(Capsule())
+                        }
+                        .buttonStyle(.plain)
+                        .help("Rename this speaker")
+                        .contextMenu {
+                            Button("Rename…") { beginSpeakerRename(speaker) }
+                            if displayedTranscript.speakerNames[speaker.nameKey] != nil {
+                                Button("Reset to \(speaker.displayName)") {
+                                    history.renameSpeaker(speaker, to: nil)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 6)
+        }
+    }
+
+    private func beginSpeakerRename(_ speaker: MeetingSpeaker) {
+        editingSpeakerName = displayedTranscript.speakerNames[speaker.nameKey] ?? ""
+        editingSpeaker = speaker
+    }
+
+    private func commitSpeakerRename(_ speaker: MeetingSpeaker) {
+        history.renameSpeaker(speaker, to: editingSpeakerName)
+        cancelSpeakerRename()
+    }
+
+    private func cancelSpeakerRename() {
+        editingSpeaker = nil
+        editingSpeakerName = ""
+        speakerFieldFocused = false
     }
 
     /// Color for a speaker badge. "You" is blue; each diarized remote speaker
@@ -226,7 +392,7 @@ struct MeetingTranscriptView: View {
     private var footerBar: some View {
         HStack(spacing: 12) {
             // Entry count
-            Text("\(meetingState.transcript.entries.count) entries")
+            Text("\(displayedTranscript.entries.count) entries")
                 .font(.caption)
                 .foregroundStyle(.tertiary)
 
@@ -234,13 +400,13 @@ struct MeetingTranscriptView: View {
 
             // Copy button
             Button {
-                meetingState.copyTranscript()
+                meetingState.copy(displayedTranscript)
             } label: {
                 Label("Copy", systemImage: SFSymbols.copy)
                     .font(.callout)
             }
             .buttonStyle(.plain)
-            .disabled(meetingState.transcript.entries.isEmpty)
+            .disabled(displayedTranscript.entries.isEmpty)
 
             // Export button
             Button {
@@ -250,7 +416,7 @@ struct MeetingTranscriptView: View {
                     .font(.callout)
             }
             .buttonStyle(.plain)
-            .disabled(meetingState.transcript.entries.isEmpty)
+            .disabled(displayedTranscript.entries.isEmpty)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 8)

--- a/Sources/WisprApp/UI/Settings/SettingsView.swift
+++ b/Sources/WisprApp/UI/Settings/SettingsView.swift
@@ -407,8 +407,6 @@ struct SettingsView: View {
             .font(.caption)
             .foregroundStyle(theme.secondaryTextColor)
 
-            Divider()
-
             HStack {
                 Text("Saved Transcripts")
                     .foregroundStyle(theme.primaryTextColor)

--- a/Sources/WisprApp/wisprApp.swift
+++ b/Sources/WisprApp/wisprApp.swift
@@ -349,8 +349,10 @@ final class WisprAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate 
         permissionMonitoringTask?.cancel()
         updateCheckTask?.cancel()
 
-        // Stop any active meeting session (synchronous — cascades via task group)
-        meetingStateManager?.cancelRecording()
+        // Stop any active meeting session (synchronous — cascades via task group).
+        // Saves the transcript first: cancelRecording() alone discards it, so
+        // quitting mid-meeting used to destroy the session with no warning.
+        meetingStateManager?.finalizeForTermination()
 
         // Stop meeting detection monitoring.
         Task { await meetingDetectionService?.stop() }

--- a/wispr.xcodeproj/project.pbxproj
+++ b/wispr.xcodeproj/project.pbxproj
@@ -82,6 +82,8 @@
 		1C74D4222FA6394300208826 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = 00C110102F60A00100000001 /* WhisperKit */; };
 		1C74D4232FA6394300208826 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = 00C110112F60A00100000002 /* FluidAudio */; };
 		1CA1B2C301000000000000A1 /* TranscriptStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA1B2C301000000000000B1 /* TranscriptStore.swift */; };
+		1CA1B2C302000000000000A1 /* MeetingHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA1B2C302000000000000B1 /* MeetingHistoryStore.swift */; };
+		1CA1B2C303000000000000A1 /* MeetingHistorySidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA1B2C303000000000000B1 /* MeetingHistorySidebar.swift */; };
 		1CAEA51D301608D800565CF0 /* ClipboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CAEA51C301608D800565CF0 /* ClipboardService.swift */; };
 		1CAEA51F301608EE00565CF0 /* UIThemeEngineMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CAEA51E301608EE00565CF0 /* UIThemeEngineMonitor.swift */; };
 		24D1D37198DFC731F192C278 /* MeetingWindowPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654DB8601B81B3E819BC5A5C /* MeetingWindowPanel.swift */; };
@@ -214,6 +216,8 @@
 		1C74D2FC2FA632B700208826 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		1C74D2FD2FA632B700208826 /* wisprApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = wisprApp.swift; sourceTree = "<group>"; };
 		1CA1B2C301000000000000B1 /* TranscriptStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptStore.swift; sourceTree = "<group>"; };
+		1CA1B2C302000000000000B1 /* MeetingHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingHistoryStore.swift; sourceTree = "<group>"; };
+		1CA1B2C303000000000000B1 /* MeetingHistorySidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingHistorySidebar.swift; sourceTree = "<group>"; };
 		1CAEA51C301608D800565CF0 /* ClipboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
 		1CAEA51E301608EE00565CF0 /* UIThemeEngineMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIThemeEngineMonitor.swift; sourceTree = "<group>"; };
 		422A849C5A34DC9AE1B8437C /* TranscriptDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptDocument.swift; sourceTree = "<group>"; };
@@ -428,6 +432,7 @@
 				1C74D2D92FA632B700208826 /* TextCorrectionService.swift */,
 				1C74D2DA2FA632B700208826 /* TextInsertionService.swift */,
 				1CA1B2C301000000000000B1 /* TranscriptStore.swift */,
+				1CA1B2C302000000000000B1 /* MeetingHistoryStore.swift */,
 				1C74D2DB2FA632B700208826 /* UpdateChecker.swift */,
 				1CAEA51C301608D800565CF0 /* ClipboardService.swift */,
 			);
@@ -519,6 +524,7 @@
 			isa = PBXGroup;
 			children = (
 				F66665AA7D70423B4954925F /* MeetingTranscriptView.swift */,
+				1CA1B2C303000000000000B1 /* MeetingHistorySidebar.swift */,
 				654DB8601B81B3E819BC5A5C /* MeetingWindowPanel.swift */,
 			);
 			path = Meeting;
@@ -745,6 +751,8 @@
 				1C74D32D2FA632B700208826 /* HotkeyRecorderView.swift in Sources */,
 				1C74D32E2FA632B700208826 /* TextInsertionService.swift in Sources */,
 				1CA1B2C301000000000000A1 /* TranscriptStore.swift in Sources */,
+				1CA1B2C302000000000000A1 /* MeetingHistoryStore.swift in Sources */,
+				1CA1B2C303000000000000A1 /* MeetingHistorySidebar.swift in Sources */,
 				1C74D32F2FA632B700208826 /* SettingsStore.swift in Sources */,
 				1C74D3302FA632B700208826 /* OnboardingModelSelectionStep.swift in Sources */,
 				1C74D3312FA632B700208826 /* SupportedLanguage.swift in Sources */,

--- a/wisprTests/TranscriptHistoryTests.swift
+++ b/wisprTests/TranscriptHistoryTests.swift
@@ -1,0 +1,290 @@
+//
+//  TranscriptHistoryTests.swift
+//  wisprTests
+//
+//  Unit tests for browsing saved transcripts: list, load, delete, rename, and
+//  the archive-safe duration used to describe them.
+//
+
+import Foundation
+import Testing
+import WisprCore
+
+@testable import WisprApp
+
+@Suite("Transcript History Tests")
+struct TranscriptHistoryTests {
+
+    /// Fixtures are dated in the year 2000 so their filenames can never collide
+    /// with a real recording sitting in the same directory, and a leaked file is
+    /// obvious rather than looking like the user's own session.
+    private func fixture(
+        offsetSeconds: TimeInterval = 0,
+        entryTexts: [String] = ["First line", "Second line"],
+        entrySpacing: TimeInterval = 30
+    ) -> MeetingTranscript {
+        let start = Date(timeIntervalSince1970: 946_684_800 + offsetSeconds)  // 2000-01-01
+        var transcript = MeetingTranscript(startTime: start)
+        for (index, text) in entryTexts.enumerated() {
+            transcript.entries.append(
+                MeetingTranscriptEntry(
+                    speaker: index.isMultiple(of: 2) ? .you : .others(speakerIndex: nil),
+                    text: text,
+                    timestamp: start.addingTimeInterval(entrySpacing * TimeInterval(index + 1))
+                )
+            )
+        }
+        return transcript
+    }
+
+    // MARK: - Duration
+
+    @Test("recordedSpan measures first-to-last entry, not time since start")
+    func testRecordedSpanIsFixedForArchived() {
+        let transcript = fixture(entryTexts: ["a", "b", "c"], entrySpacing: 60)
+        // Entries land at +60, +120, +180 from startTime.
+        #expect(transcript.recordedSpan == 180)
+        #expect(transcript.formattedRecordedSpan == "3:00")
+    }
+
+    @Test("formattedRecordedSpan renders hours instead of overflowing minutes")
+    func testFormattedSpanIncludesHours() {
+        let transcript = fixture(entryTexts: ["only"], entrySpacing: 8_130)  // 2h 15m 30s
+        #expect(transcript.formattedRecordedSpan == "2:15:30")
+    }
+
+    @Test("an empty transcript has a zero span rather than a negative one")
+    func testEmptySpanIsZero() {
+        let transcript = MeetingTranscript()
+        #expect(transcript.recordedSpan == 0)
+    }
+
+    // MARK: - Listing
+
+    @Test("list includes a saved session with its entry count and span")
+    func testListIncludesSavedSession() throws {
+        let transcript = fixture(offsetSeconds: 10)
+        let url = try #require(TranscriptStore.save(transcript))
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let summary = try #require(TranscriptStore.list().first { $0.url == url })
+        #expect(summary.entryCount == 2)
+        #expect(summary.span == 60)  // entries at +30 and +60
+        #expect(summary.preview == "First line")
+        #expect(summary.title == nil)
+    }
+
+    @Test("list is ordered newest first")
+    func testListIsNewestFirst() throws {
+        let older = try #require(TranscriptStore.save(fixture(offsetSeconds: 100)))
+        defer { try? FileManager.default.removeItem(at: older) }
+        let newer = try #require(TranscriptStore.save(fixture(offsetSeconds: 200)))
+        defer { try? FileManager.default.removeItem(at: newer) }
+
+        let urls = TranscriptStore.list().map(\.url)
+        let olderIndex = try #require(urls.firstIndex(of: older))
+        let newerIndex = try #require(urls.firstIndex(of: newer))
+        #expect(newerIndex < olderIndex)
+    }
+
+    // MARK: - Loading
+
+    @Test("load returns the transcript that was written")
+    func testLoadRoundTrip() throws {
+        let url = try #require(TranscriptStore.save(fixture(offsetSeconds: 300)))
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let loaded = try #require(TranscriptStore.load(url))
+        #expect(loaded.entries.count == 2)
+        #expect(loaded.entries[0].text == "First line")
+        #expect(loaded.entries[1].speaker == .others(speakerIndex: nil))
+    }
+
+    @Test("load returns nil for a file that is not a transcript")
+    func testLoadRejectsGarbage() throws {
+        let url = TranscriptStore.directory
+            .appendingPathComponent("meeting-2000-01-01_00-00-00-garbage.json")
+        try FileManager.default.createDirectory(
+            at: TranscriptStore.directory, withIntermediateDirectories: true)
+        try Data("not json".utf8).write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        #expect(TranscriptStore.load(url) == nil)
+        // A damaged file must not hide the rest of the history.
+        #expect(!TranscriptStore.list().contains { $0.url == url })
+    }
+
+    // MARK: - Renaming
+
+    @Test("rename stores the title and slugs it into the filename")
+    func testRenameSetsTitleAndSlug() throws {
+        let original = try #require(TranscriptStore.save(fixture(offsetSeconds: 400)))
+        var finalURL = original
+        defer { try? FileManager.default.removeItem(at: finalURL) }
+
+        finalURL = try #require(TranscriptStore.rename(original, to: "Sprint Review!"))
+
+        #expect(finalURL.lastPathComponent.hasPrefix("meeting-"))
+        #expect(finalURL.lastPathComponent.contains("sprint-review"))
+        #expect(finalURL.lastPathComponent.hasSuffix(".json"))
+
+        let reloaded = try #require(TranscriptStore.load(finalURL))
+        #expect(reloaded.title == "Sprint Review!")
+
+        let summary = try #require(TranscriptStore.list().first { $0.url == finalURL })
+        #expect(summary.displayName == "Sprint Review!")
+    }
+
+    @Test("rename to nil clears the title and reverts to the date")
+    func testRenameClearsTitle() throws {
+        let original = try #require(TranscriptStore.save(fixture(offsetSeconds: 500)))
+        var finalURL = try #require(TranscriptStore.rename(original, to: "Temporary"))
+        defer { try? FileManager.default.removeItem(at: finalURL) }
+
+        finalURL = try #require(TranscriptStore.rename(finalURL, to: nil))
+
+        let reloaded = try #require(TranscriptStore.load(finalURL))
+        #expect(reloaded.title == nil)
+
+        let summary = try #require(TranscriptStore.list().first { $0.url == finalURL })
+        // Falls back to a formatted date, which is never the cleared title.
+        #expect(summary.displayName != "Temporary")
+    }
+
+    @Test("rename treats whitespace as clearing the title")
+    func testRenameWhitespaceClearsTitle() throws {
+        let original = try #require(TranscriptStore.save(fixture(offsetSeconds: 600)))
+        var finalURL = try #require(TranscriptStore.rename(original, to: "Named"))
+        defer { try? FileManager.default.removeItem(at: finalURL) }
+
+        finalURL = try #require(TranscriptStore.rename(finalURL, to: "   "))
+        let reloaded = try #require(TranscriptStore.load(finalURL))
+        #expect(reloaded.title == nil)
+    }
+
+    // MARK: - Deleting
+
+    @Test("delete removes the file and it drops out of the listing")
+    func testDeleteRemovesSession() throws {
+        let url = try #require(TranscriptStore.save(fixture(offsetSeconds: 700)))
+
+        #expect(TranscriptStore.delete(url))
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+        #expect(!TranscriptStore.list().contains { $0.url == url })
+    }
+
+    @Test("delete reports failure for a file that is not there")
+    func testDeleteMissingFileFails() {
+        let missing = TranscriptStore.directory
+            .appendingPathComponent("meeting-2000-01-01_00-00-00-absent.json")
+        #expect(!TranscriptStore.delete(missing))
+    }
+
+    // MARK: - Speaker names
+
+    @Test("a named speaker replaces the generated label")
+    func testSetNameOverridesDisplayName() {
+        var transcript = fixture()
+        let speaker = MeetingSpeaker.others(speakerIndex: 1)
+
+        #expect(transcript.displayName(for: speaker) == "Speaker 2")
+        transcript.setName("Danilo", for: speaker)
+        #expect(transcript.displayName(for: speaker) == "Danilo")
+    }
+
+    @Test("clearing a speaker name falls back to the generated label")
+    func testClearingSpeakerName() {
+        var transcript = fixture()
+        let speaker = MeetingSpeaker.you
+
+        transcript.setName("Gabriel", for: speaker)
+        #expect(transcript.displayName(for: speaker) == "Gabriel")
+
+        transcript.setName("   ", for: speaker)
+        #expect(transcript.displayName(for: speaker) == "You")
+        #expect(transcript.speakerNames["you"] == nil)
+    }
+
+    @Test("speaker names are keyed per diarization index, not shared")
+    func testNamesArePerSpeaker() {
+        var transcript = fixture()
+        transcript.setName("Ana", for: .others(speakerIndex: 0))
+        transcript.setName("Bruno", for: .others(speakerIndex: 1))
+
+        #expect(transcript.displayName(for: .others(speakerIndex: 0)) == "Ana")
+        #expect(transcript.displayName(for: .others(speakerIndex: 1)) == "Bruno")
+        // The unresolved track is a separate identity from any indexed speaker.
+        #expect(transcript.displayName(for: .others(speakerIndex: nil)) == "Others")
+    }
+
+    @Test("plain text export uses assigned speaker names")
+    func testPlainTextUsesNames() {
+        var transcript = fixture(entryTexts: ["Hello there"])
+        transcript.setName("Gabriel", for: .you)
+
+        let text = transcript.asPlainText()
+        #expect(text.contains("Gabriel: Hello there"))
+        #expect(!text.contains("You: Hello there"))
+    }
+
+    @Test("presentSpeakers lists each speaker once, local first")
+    func testPresentSpeakersOrdering() {
+        let start = Date(timeIntervalSince1970: 946_684_800)
+        var transcript = MeetingTranscript(startTime: start)
+        transcript.entries = [
+            MeetingTranscriptEntry(speaker: .others(speakerIndex: 1), text: "b", timestamp: start),
+            MeetingTranscriptEntry(speaker: .you, text: "a", timestamp: start),
+            MeetingTranscriptEntry(speaker: .others(speakerIndex: nil), text: "c", timestamp: start),
+            MeetingTranscriptEntry(speaker: .others(speakerIndex: 0), text: "d", timestamp: start),
+            MeetingTranscriptEntry(speaker: .you, text: "e", timestamp: start),
+        ]
+
+        #expect(
+            transcript.presentSpeakers == [
+                .you,
+                .others(speakerIndex: 0),
+                .others(speakerIndex: 1),
+                .others(speakerIndex: nil),
+            ])
+    }
+
+    @Test("speaker names survive a save and reload")
+    func testSpeakerNamesPersist() throws {
+        var transcript = fixture(offsetSeconds: 800)
+        transcript.setName("Danilo", for: .others(speakerIndex: nil))
+
+        let url = try #require(TranscriptStore.save(transcript))
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let reloaded = try #require(TranscriptStore.load(url))
+        #expect(reloaded.displayName(for: .others(speakerIndex: nil)) == "Danilo")
+    }
+
+    @Test("a transcript written before speaker names existed still decodes")
+    func testLegacyTranscriptWithoutSpeakerNamesDecodes() throws {
+        // Exactly the shape older builds wrote: no speakerNames, no title.
+        let legacy = """
+            {
+              "entries" : [
+                {
+                  "id" : "\(UUID().uuidString)",
+                  "speaker" : { "you" : {} },
+                  "text" : "Legacy entry",
+                  "timestamp" : "2000-01-01T00:00:30Z"
+                }
+              ],
+              "startTime" : "2000-01-01T00:00:00Z"
+            }
+            """
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let transcript = try decoder.decode(
+            MeetingTranscript.self, from: Data(legacy.utf8))
+
+        #expect(transcript.entries.count == 1)
+        #expect(transcript.title == nil)
+        #expect(transcript.speakerNames.isEmpty)
+        #expect(transcript.displayName(for: .you) == "You")
+    }
+}


### PR DESCRIPTION
## Summary

Saved meeting transcripts were already being written to disk, but there was no way back to them from the app. This adds a history sidebar to the meeting window, plus the naming and cleanup operations that make an archive usable.

## What's in it

- **History sidebar** (`MeetingHistorySidebar`) listing saved sessions newest-first, with open / rename / delete.
- **`MeetingHistoryStore`** owns the list and the current selection. Kept deliberately separate from `MeetingStateManager` so that browsing history can never disturb a recording in progress, and starting a meeting can't wipe an archive the user is reading.
- **`TranscriptStore`** gains `list` / `load` / `delete` / `rename` alongside the existing `save`. Titles live inside the JSON and are only *slugged* into the filename, so the timestamp stays authoritative and filename and content can't drift into disagreement. Nothing is ever read back out of a filename.
- **Speaker naming**, keyed by diarization index, offered on finished sessions (which is when you actually know who "Speaker 2" was). Names flow through to copy and export, so an exported transcript reads the same as what's on screen.
- **`recordedSpan`** describes a saved session by its first-to-last timestamp. The existing `duration` is measured against *now*, which is correct while recording but grows forever for a session loaded from disk.
- **Backward-compatible decoding.** `MeetingTranscript` now decodes explicitly rather than by synthesis: the synthesized initializer requires every key to be present and does not fall back to a property's default, so adding `title` and `speakerNames` would otherwise fail to decode every transcript written before this change.
- A stray `Divider()` in the Meeting settings section is dropped. Inside a `Form` section macOS lays it out as its own inset row, so it read as an empty row above **Saved Transcripts** rather than as a separator.

## Bug fix included

`applicationWillTerminate` called `cancelRecording()`, which discards the transcript, so quitting mid-meeting destroyed the session with no warning. `stopMeeting()` can't be used there because it is `async` and the process is torn down before the suspension would resume, so `finalizeForTermination()` writes the session inline first and then cancels.

Happy to split that out into its own PR if you'd rather land it independently.

## Testing

- 19 new tests in `TranscriptHistoryTests`, covering listing order, load / delete, rename and filename slugging, speaker-name persistence and per-index keying, decoding of transcripts written before names existed, and span formatting.
- Full suite: 553 tests, all passing except `AudioEngine audio level stream terminates on stop`. That one is pre-existing on `main` — I confirmed by running the full suite there and getting the same single failure — and it passes in isolation on both branches, so it looks like microphone contention under the parallel run.
- `swift build --target WisprApp` clean.
- Also verified as a signed Release build installed and running locally on macOS 26.
