### PR TITLE
feat(website): redesign landing page with dark theme and animated hero

### DIFF
--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -1,0 +1,101 @@
+# Product Website Redesign — CLAUDE.md
+
+## Rules (non-negotiable)
+
+- Always invoke the `ui-ux-pro-max` skill before writing any frontend code. No exceptions, even for small edits.
+- Output is **static HTML/CSS/JS only** — no build step, no bundler, no frameworks (no React/Vue/etc.), no external JS dependencies beyond what's needed for the carousel.
+- All code lives under `website/`. Do not scatter files elsewhere.
+- Semantic HTML throughout (proper heading hierarchy, `<section>`/`<nav>`/`<button>` over generic `<div>`s).
+- Fully responsive: mobile, tablet, desktop breakpoints.
+- Accessible: alt text on all images, keyboard-navigable carousel (arrow keys + visible focus states), sufficient color contrast against the palette below.
+
+## File structure to produce
+
+```
+website/
+├── index.html
+├── styles.css
+├── script.js
+├── icon.svg
+├── screenshots/
+│   ├── menu.png
+│   ├── settings.png
+│   ├── model-management.png
+│   └── onboarding-01.png ... onboarding-06.png
+└── README.md
+```
+
+- Treat everything under `screenshots/` and `icon.svg` as **pre-existing assets** — reference them by path, do not attempt to generate or fabricate image content for them.
+- If an asset is missing when you check the folder, flag it rather than silently substituting a placeholder.
+
+## Sections (in order)
+
+1. **Hero** — logo, headline, call-to-action
+2. **Download/Install** — Homebrew install command(s), download button, donate option
+3. **Features** — 4 features, card layout
+4. **How It Works** — 3-step process
+5. **Onboarding** — interactive carousel, 6 steps (`onboarding-01.png` – `onboarding-06.png`)
+6. **Screenshots** — visual showcase (menu, settings, model-management)
+7. **Use Cases** — 4 user scenarios
+8. **Support** — donation CTA with Revolut link
+9. **Footer** — links, copyright
+
+## Design tokens
+
+Define as CSS variables in `styles.css`, editable at the top of the file:
+
+```css
+:root {
+  --primary-blue: rgb(84, 155, 230);
+  --deep-blue: rgb(33, 38, 162);
+  --light-blue: rgb(173, 225, 252);
+}
+```
+
+Extend this token set (typography scale, spacing, dark-mode variables) as needed per the `frontend-design` skill's guidance — don't leave it at just three colors.
+
+## Visual reference (match this style)
+
+A reference screenshot (Osmo-style landing page) defines the target aesthetic. Match these attributes — not the literal copy or brand:
+
+**Palette & background**
+
+- Near-black background (`#0a0a0a` – `#111` range), not pure `#000`
+- A single warm accent color used sparingly but boldly (their orange `~#ff4d1f` → substitute our `--primary-blue` family for the equivalent glow effect)
+- Subtle film-grain/noise texture overlaid on the background (CSS `filter` + SVG noise, or a repeating noise PNG at low opacity) — this is a defining detail, not decoration to skip
+- The hero background is NOT a single soft blob. It's built from 3–5 large overlapping arc/crescent shapes (like offset, oversized rings or C-shapes), each filled with a blurred gradient and varying opacity (roughly 15–60%), layered so their edges cut across each other and create banded, sliced glow regions rather than one uniform glow. Implement as an inline `<svg>` with several `<path>` or `<circle>` elements (thick strokes or filled crescents via arcs), each with a Gaussian blur `<filter>` and a gradient fill referencing the design tokens — not a single `radial-gradient()` CSS background. This layered-arc construction is the single most defining visual element of the reference and should not be simplified to one blob.
+
+**Typography**
+
+- Hero headline: very large (clamp ~64–110px), tight line-height, bold sans-serif, white text over dark background, wraps to 2 lines
+- Body/nav text: light gray (~`#a0a0a0`), smaller, generous letter-spacing on secondary links
+
+**Layout patterns**
+
+- Top nav: logo left, centered primary nav links, auth/CTA buttons right (ghost "Log in" + solid button)
+- Two stacked secondary link columns positioned left-mid-page (small muted text, e.g. resource/doc categories) — decorative wayfinding, not primary nav
+- Hero CTA row: one solid light button + one dark/glass button containing small avatar/icon stack + label
+- Supporting paragraph block anchored lower-left of hero, constrained width (~400px), muted gray text
+- Thin decorative line/crosshair elements as accents near lower-right — hairline strokes, low opacity
+
+**Motion cues (if adding JS)**
+
+- Subtle parallax or slow drift on the background glow
+- Buttons: slight scale/opacity transition on hover, no jarring movement
+
+Apply this treatment primarily to the **Hero** section; carry the dark theme, grain texture, and accent-glow language through the rest of the page (Features, How It Works, etc.) for consistency, but you don't need to replicate the exact blob/crosshair motif everywhere.
+
+## Browser support target
+
+Chrome/Edge 90+, Firefox 88+, Safari 14+, modern mobile browsers. Use CSS scroll-snap for section/carousel scrolling with a smooth-scroll fallback for browsers that don't support it — don't gate functionality behind it.
+
+## Definition of done
+
+Before considering the task complete, verify:
+
+- [ ] All 9 sections present and in order in `index.html`
+- [ ] Carousel works via click/swipe AND keyboard (arrow keys, focus-visible)
+- [ ] Page is usable at 375px, 768px, and 1440px widths
+- [ ] No console errors when `index.html` is opened directly (file://) or served locally
+- [ ] No build step required — opening `index.html` works as-is
+- [ ] `website/README.md` exists and matches the deployment/customization docs (see separate README content)

--- a/website/README.md
+++ b/website/README.md
@@ -141,6 +141,16 @@ arrive together rather than in sequence. To retime the entrance, edit those
 `<head>` rather than by `script.js`, because they have to be in place before the
 first paint — set them later and you get a flash of unstyled content. Nothing is
 hidden unless that script runs, so with JS disabled the page is simply visible.
+
+Because those classes hide things (`intro-loader` covers the page, `intro-armed`
+holds the hero, `reveal-armed` sits the later sections at `opacity: 0`), the
+inline script also carries a failsafe for the case where it runs but `script.js`
+does not — a 404, a blocking extension or proxy, a syntax error. `script.js` sets
+`document.documentElement.dataset.introReady = '1'` on its last line; the inline
+script checks that flag on `DOMContentLoaded` and, if it is unset, strips all
+three classes. The page then renders plain and fully visible instead of stranded
+behind the curtain. Keep that assignment as the final statement of `script.js`:
+moved earlier, it stops covering a mid-file throw.
 The curtain shows once per browser session (a `wispr-intro` key in
 `sessionStorage`); later loads keep the stagger and skip the curtain. Under
 `prefers-reduced-motion: reduce` there is no curtain, no stagger and no spring —

--- a/website/README.md
+++ b/website/README.md
@@ -26,6 +26,72 @@ Edit the CSS variables at the top of `styles.css`:
 }
 ```
 
+### Hero wave background
+
+The animated field behind the hero is rendered on a WebGL2 canvas by `waves.js`.
+It is a dependency-free port of the React Bits `GradientWaves` component — the
+GLSL shader is unchanged, but the `ogl` scaffolding was rewritten against the raw
+WebGL2 API, so there is still no build step and nothing to install.
+
+**Tuning it.** Every parameter lives in the `WAVES_CONFIG` block at the top of
+`waves.js`. Edit a value and reload, or open the page with `?tune=1` for a live
+control panel:
+
+```
+index.html?tune=1
+```
+
+The panel gives you a slider, picker or toggle for all 21 parameters and a
+**Copy config** button that emits a `WAVES_CONFIG` block you can paste straight
+back into `waves.js`. **Reset** returns everything to the values in the file. The
+panel is only built when `?tune=1` (or `#tune`) is present, so visitors never see
+it, and it also exposes `window.__waves` for tweaking from the console:
+
+```js
+__waves.apply({ speed: 0.6, brightness: 1.2 });
+```
+
+The three colors accept a design-token reference, so the palette stays defined in
+one place — `var(--deep-blue)` resolves against the variables in `styles.css`.
+Plain `#rrggbb` and `rgb()` values work too.
+
+| Key | Default | What it does |
+|-----|---------|--------------|
+| `horizonColor` | `var(--deep-blue)` | Distant haze the waves fade into |
+| `waveColor` | `var(--primary-blue)` | Mid color of the rolling wave bodies |
+| `crestColor` | `#FFFFFF` | Highlight on the nearest crests |
+| `speed` | `0.3` | Animation speed of the field |
+| `amplitude` | `3.0` | Height of the waves |
+| `waveScale` | `0.5` | Overall spatial frequency |
+| `waveRatio` | `0.9` | Ratio of short to long wavelength components |
+| `swell` | `35` | Large-scale horizontal swell distortion |
+| `turbulence` | `20` | Large-scale cross-flow turbulence |
+| `tilt` | `1.02` | Camera pitch toward the horizon, in radians |
+| `zoom` | `1.0` | Field-of-view zoom |
+| `height` | `2.8` | Vertical offset of the horizon line |
+| `fogDepth` | `32` | Distance over which waves fade into haze |
+| `detail` | `'medium'` | Raymarch quality: `low`, `medium`, `high` |
+| `brightness` | `1.5` | Final color multiplier |
+| `opacity` | `1.0` | Global opacity of the effect |
+| `mouseInteraction` | `true` | Pointer-driven camera parallax |
+| `parallaxStrength` | `0.5` | Strength of the cursor drift |
+| `grain` | `false` | Shader film grain (the page already has a grain overlay) |
+| `grainIntensity` | `0.05` | Amplitude of that grain |
+| `maxDpr` | `2` | Render-buffer resolution ceiling |
+
+**Behaviour worth knowing.** The render loop is paused whenever the hero scrolls
+out of view or the tab is hidden. Under `prefers-reduced-motion: reduce` the
+field is drawn once as a still frame and never animates. If WebGL2 is
+unavailable — or JS is off entirely — the hero falls back to the CSS glow in
+`styles.css` (`.hero-glow`), which is otherwise hidden by the `.waves-active`
+class. The `.hero-scrim` layer sits between the canvas and the copy to keep hero
+text above the 4.5:1 contrast threshold; if you brighten the waves a lot, darken
+the scrim to match.
+
+Turning the effect off completely: delete the `<div class="hero-waves">` and
+`<div class="hero-scrim">` elements plus the `waves.js` script tag from
+`index.html`. The CSS glow takes over with no other changes.
+
 ### Content
 
 Edit the text directly in `index.html`. The structure is semantic and organized by section, so it's easy to find and change.
@@ -44,6 +110,9 @@ All images live in the website directory:
 - `screenshots/model-management.png` — model management screenshot
 - `screenshots/onboarding-01.png` through `onboarding-06.png` — onboarding flow screenshots
 
+Scripts: `script.js` handles the nav, carousel and copy buttons; `waves.js`
+renders the hero background.
+
 The site is fully self-contained and portable — copy the `website/` folder anywhere and it works.
 
 ## Browser Support
@@ -52,5 +121,10 @@ The site is fully self-contained and portable — copy the `website/` folder any
 - Firefox 88+
 - Safari 14+
 - All modern mobile browsers
+
+The hero wave background needs WebGL2, which lands in Safari 15 — Safari 14 and
+any browser with WebGL2 disabled or unavailable (including software-rendering
+blocklists) fall back to the CSS glow automatically. Every other part of the page
+is unaffected.
 
 Scroll-snap is used for smooth section/carousel scrolling and is supported in all modern browsers; older browsers fall back to standard smooth scrolling.

--- a/website/README.md
+++ b/website/README.md
@@ -41,9 +41,10 @@ control panel:
 index.html?tune=1
 ```
 
-The panel gives you a slider, picker or toggle for all 21 parameters and a
+The panel gives you a slider, picker or toggle for all 25 parameters, a
 **Copy config** button that emits a `WAVES_CONFIG` block you can paste straight
-back into `waves.js`. **Reset** returns everything to the values in the file. The
+back into `waves.js`, and **Replay intro** to watch the load animation again
+without reloading. **Reset** returns everything to the values in the file. The
 panel is only built when `?tune=1` (or `#tune`) is present, so visitors never see
 it, and it also exposes `window.__waves` for tweaking from the console:
 
@@ -61,23 +62,27 @@ Plain `#rrggbb` and `rgb()` values work too.
 | `waveColor` | `var(--primary-blue)` | Mid color of the rolling wave bodies |
 | `crestColor` | `#FFFFFF` | Highlight on the nearest crests |
 | `speed` | `0.3` | Animation speed of the field |
-| `amplitude` | `3.0` | Height of the waves |
+| `amplitude` | `3.7` | Height of the waves |
 | `waveScale` | `0.5` | Overall spatial frequency |
 | `waveRatio` | `0.9` | Ratio of short to long wavelength components |
 | `swell` | `35` | Large-scale horizontal swell distortion |
 | `turbulence` | `20` | Large-scale cross-flow turbulence |
 | `tilt` | `1.02` | Camera pitch toward the horizon, in radians |
-| `zoom` | `1.0` | Field-of-view zoom |
+| `zoom` | `1` | Field-of-view zoom, and the target the intro springs to |
 | `height` | `2.8` | Vertical offset of the horizon line |
 | `fogDepth` | `32` | Distance over which waves fade into haze |
 | `detail` | `'medium'` | Raymarch quality: `low`, `medium`, `high` |
 | `brightness` | `1.5` | Final color multiplier |
-| `opacity` | `1.0` | Global opacity of the effect |
+| `opacity` | `1` | Global opacity of the effect |
+| `intro` | `true` | Spring the zoom in on load |
+| `introZoomFrom` | `0.43` | Zoom the intro starts from (lower = wider) |
+| `introStiffness` | `60` | Spring constant; higher snaps faster |
+| `introDamping` | `31` | Friction. Overshoot needs this under `2 * sqrt(introStiffness)` — about `15.5` at the current stiffness, so the default eases in with no bounce |
 | `mouseInteraction` | `true` | Pointer-driven camera parallax |
 | `parallaxStrength` | `0.5` | Strength of the cursor drift |
-| `grain` | `false` | Shader film grain (the page already has a grain overlay) |
-| `grainIntensity` | `0.05` | Amplitude of that grain |
-| `maxDpr` | `2` | Render-buffer resolution ceiling |
+| `grain` | `true` | Shader film grain, on top of the page-wide grain overlay |
+| `grainIntensity` | `0.095` | Amplitude of that grain |
+| `maxDpr` | `2` | Render-buffer resolution ceiling. Each step up multiplies the shaded pixel count, and this shader is the most expensive thing on the page |
 
 **Behaviour worth knowing.** The render loop is paused whenever the hero scrolls
 out of view or the tab is hidden. Under `prefers-reduced-motion: reduce` the
@@ -91,6 +96,58 @@ the scrim to match.
 Turning the effect off completely: delete the `<div class="hero-waves">` and
 `<div class="hero-scrim">` elements plus the `waves.js` script tag from
 `index.html`. The CSS glow takes over with no other changes.
+
+### Load curtain & hero entrance
+
+On first visit the page holds behind a curtain — the wordmark over a hairline
+that fills with `--primary-blue` — then lifts into a staggered reveal of the hero
+copy while the wave field springs its zoom open. The curtain lives in
+`index.html`; the sequencing is at the bottom of `script.js`.
+
+**It waits on real signals, not a timer:** `document.fonts.ready`, `window.load`,
+and the first painted wave frame (`waves.js` fires a `wispr:waves-ready` event).
+The fill advances as each one lands. Three guards keep that honest:
+
+- `MIN_HOLD` (450ms) — the floor, so a warm cache doesn't flash the curtain for a
+  single frame
+- `FAILSAFE` (1200ms) — lifts regardless, so a stalled signal can never strand
+  the page
+- the wave signal also resolves 200ms after `load`, so a machine without WebGL2
+  isn't waiting on a frame that will never arrive
+
+Both constants are at the top of that block in `script.js`. `MIN_HOLD` is the one
+that changes how the wait *feels*.
+
+**The reveal.** Lifting the curtain removes `intro-armed` from `<html>`, which
+plays every hero beat at once — each element offset by its own `--intro-delay`,
+set per element near the bottom of `styles.css`:
+
+| Element | Delay |
+| --- | --- |
+| `.hero-eyebrow` | 60ms |
+| headline line 1 | 120ms |
+| headline line 2 | 180ms |
+| `.hero-cta` | 260ms |
+| `.hero-blurb` | 340ms |
+| `.hero-wayfinding` | 340ms |
+
+The same moment releases the zoom spring, so the background motion and the copy
+arrive together rather than in sequence. To retime the entrance, edit those
+`--intro-delay` values; to change the distance or curve, edit the shared
+`[data-intro]` rule above them. Elements opt in purely by carrying a
+`data-intro` attribute in `index.html`.
+
+**Things to know before editing.** The classes are set by an inline `<script>` in
+`<head>` rather than by `script.js`, because they have to be in place before the
+first paint — set them later and you get a flash of unstyled content. Nothing is
+hidden unless that script runs, so with JS disabled the page is simply visible.
+The curtain shows once per browser session (a `wispr-intro` key in
+`sessionStorage`); later loads keep the stagger and skip the curtain. Under
+`prefers-reduced-motion: reduce` there is no curtain, no stagger and no spring —
+the final state paints immediately. And if an element already carries its own
+`transform`, the entrance offset has to be composed into it rather than layered
+on: `.hero-wayfinding` is centred with `translateY(-50%)`, so it has a dedicated
+armed rule. Skip that and it slides its whole centring offset instead of 12px.
 
 ### Content
 
@@ -110,8 +167,8 @@ All images live in the website directory:
 - `screenshots/model-management.png` — model management screenshot
 - `screenshots/onboarding-01.png` through `onboarding-06.png` — onboarding flow screenshots
 
-Scripts: `script.js` handles the nav, carousel and copy buttons; `waves.js`
-renders the hero background.
+Scripts: `script.js` handles the nav, carousel, copy buttons and the load
+curtain; `waves.js` renders the hero background.
 
 The site is fully self-contained and portable — copy the `website/` folder anywhere and it works.
 

--- a/website/README.md
+++ b/website/README.md
@@ -1,112 +1,50 @@
-# Wispr Promotional Website
+# Website
 
-A modern, single-page promotional website for Wispr voice dictation app with full-page scroll snapping sections.
+A static, self-contained product website. No build step required.
 
-## Features
+## Deployment
 
-- **Scroll Snapping**: Apple-style full-page sections with smooth snap scrolling
-- **Modern Design**: Clean, engaging layout inspired by Apple's product pages
-- **Color Theme**: Uses the blue gradient color palette from Wispr's logo
-- **Responsive**: Works beautifully on desktop, tablet, and mobile
-- **Animations**: Smooth fade-in effects and parallax scrolling
-- **Keyboard Navigation**: Use arrow keys to navigate between sections
+This site is plain HTML/CSS/JS and can be deployed anywhere that serves static files:
 
-## Structure
-
-```
-website/
-├── index.html              # Main HTML structure
-├── styles.css              # All styling and animations
-├── script.js               # Interactive features and animations
-├── icon.svg                # Wispr logo
-├── CNAME                   # Custom domain configuration
-├── screenshots/            # App screenshots
-│   ├── menu.png
-│   ├── settings.png
-│   ├── model-management.png
-│   ├── onboarding-01.png
-│   ├── onboarding-02.png
-│   ├── onboarding-03.png
-│   ├── onboarding-04.png
-│   ├── onboarding-05.png
-│   └── onboarding-06.png
-└── README.md               # This file
-```
-
-The website is completely self-contained with all assets included.
-
-## Sections
-
-1. **Hero** - Eye-catching introduction with logo and call-to-action
-2. **Download/Install** - Homebrew installation commands and download button with donate option
-3. **Features** - Four key features in card layout
-4. **How It Works** - Three-step process explanation
-5. **Onboarding** - Interactive carousel showing the 6-step onboarding experience
-6. **Screenshots** - Visual showcase of the app interface
-7. **Use Cases** - Four different user scenarios
-8. **Support** - Donation call-to-action with Revolut link
-9. **Footer** - Links and copyright information
-
-## Usage
-
-### Local Development
-
-Simply open `index.html` in a web browser:
-
-```bash
-open index.html
-```
-
-Or use a local server:
-
-```bash
-# Python 3
-python3 -m http.server 8000
-
-# Node.js (with http-server)
-npx http-server
-```
-
-Then visit `http://localhost:8000`
-
-### Deployment
-
-The website is static HTML/CSS/JS and can be deployed to:
-
-- **GitHub Pages**: Push to a `gh-pages` branch
-- **Netlify**: Drag and drop the `website` folder
-- **Vercel**: Connect your repository
-- **Any static hosting**: Upload the files via FTP/SFTP
+- **GitHub Pages**: push the contents of `website/` to a `gh-pages` branch
+- **Netlify**: drag and drop the `website` folder into the Netlify dashboard
+- **Vercel**: connect your repository and set the root directory to `website`
+- **Any static host**: upload the files via FTP/SFTP
 
 ## Customization
 
 ### Colors
 
-Edit the CSS variables in `styles.css`:
+Edit the CSS variables at the top of `styles.css`:
 
 ```css
 :root {
-    --primary-blue: rgb(84, 155, 230);
-    --deep-blue: rgb(33, 38, 162);
-    --light-blue: rgb(173, 225, 252);
-    /* ... */
+  --primary-blue: rgb(84, 155, 230);
+  --deep-blue: rgb(33, 38, 162);
+  --light-blue: rgb(173, 225, 252);
+  /* ... */
 }
 ```
 
 ### Content
 
-Edit the text directly in `index.html`. The structure is semantic and easy to modify.
+Edit the text directly in `index.html`. The structure is semantic and organized by section, so it's easy to find and change.
+
+### Fonts
+
+Headings use [Space Grotesk](https://fonts.google.com/specimen/Space+Grotesk) and body text uses [DM Sans](https://fonts.google.com/specimen/DM+Sans), loaded from Google Fonts in `index.html`. If the fonts can't load (e.g. offline), the site falls back to system fonts and remains fully usable. To change fonts, edit the `<link>` in `index.html` and the `--font-heading` / `--font-body` variables in `styles.css`.
 
 ### Images
 
-All images are included in the website directory:
-- `icon.svg` - Wispr logo
-- `screenshots/menu.png` - Menu bar screenshot
-- `screenshots/settings.png` - Settings screenshot
-- `screenshots/model-management.png` - Model management screenshot
-- `screenshots/onboarding-01.png` through `onboarding-06.png` - Onboarding flow screenshots
+All images live in the website directory:
 
-The website is completely self-contained and portable.
+- `icon.svg` — logo
+- `screenshots/menu.png` — menu bar screenshot
+- `screenshots/settings.png` — settings screenshot
+- `screenshots/model-management.png` — model management screenshot
+- `screenshots/onboarding-01.png` through `onboarding-06.png` — onboarding flow screenshots
+
+The site is fully self-contained and portable — copy the `website/` folder anywhere and it works.
 
 ## Browser Support
 
@@ -115,16 +53,4 @@ The website is completely self-contained and portable.
 - Safari 14+
 - All modern mobile browsers
 
-The scroll-snap feature is supported in all modern browsers. Older browsers will fall back to smooth scrolling.
-
-## Performance
-
-- No external dependencies
-- Minimal JavaScript
-- Optimized CSS animations
-- Fast loading time
-- Lighthouse score: 95+
-
-## License
-
-Same as the Wispr project.
+Scroll-snap is used for smooth section/carousel scrolling and is supported in all modern browsers; older browsers fall back to standard smooth scrolling.

--- a/website/index.html
+++ b/website/index.html
@@ -17,12 +17,24 @@
         var root = document.documentElement;
         root.classList.add("js");
         if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
-        root.classList.add("intro-armed");
+        root.classList.add("intro-armed", "reveal-armed");
         var seen = false;
         try {
           seen = sessionStorage.getItem("wispr-intro") === "1";
         } catch (e) {}
         if (!seen) root.classList.add("intro-loader");
+
+        // Every class above hides something until script.js takes over: the
+        // curtain covers the page, the hero waits, later sections sit at
+        // opacity 0. If script.js never runs -- 404, blocked by an extension
+        // or proxy, parse error -- nothing would ever lift them. DOMContentLoaded
+        // still fires in all of those cases, and by then a healthy script.js has
+        // set introReady, so an unset flag means the enhancement is gone: strip
+        // the armed state and leave a plain, fully visible page.
+        document.addEventListener("DOMContentLoaded", function () {
+          if (root.dataset.introReady === "1") return;
+          root.classList.remove("intro-armed", "intro-loader", "reveal-armed");
+        });
       })();
     </script>
     <title>Wispr - Voice Dictation for Mac</title>

--- a/website/index.html
+++ b/website/index.html
@@ -8,6 +8,23 @@
     ></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- Runs before first paint so the curtain and the pre-animation state are
+         already in place: adding these classes later would flash unstyled
+         content. Everything degrades to plain visible content without JS. -->
+    <script>
+      (function () {
+        var root = document.documentElement;
+        root.classList.add("js");
+        if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+        root.classList.add("intro-armed");
+        var seen = false;
+        try {
+          seen = sessionStorage.getItem("wispr-intro") === "1";
+        } catch (e) {}
+        if (!seen) root.classList.add("intro-loader");
+      })();
+    </script>
     <title>Wispr - Voice Dictation for Mac</title>
     <meta
       name="description"
@@ -66,6 +83,16 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body id="top">
+    <!-- Load curtain. Same background as the page, so it reads as a held
+         moment rather than a separate screen. Removed by script.js. -->
+    <div class="loader" aria-hidden="true">
+      <div class="loader-mark">
+        <img src="icon.svg" alt="" width="26" height="26" />
+        <span>Wispr</span>
+      </div>
+      <div class="loader-track"><span class="loader-fill"></span></div>
+    </div>
+
     <a class="skip-link" href="#main">Skip to content</a>
 
     <header class="site-header">
@@ -111,7 +138,7 @@
           <span class="crosshair-diag"></span>
         </div>
 
-        <nav class="hero-wayfinding" aria-label="Section shortcuts">
+        <nav class="hero-wayfinding" data-intro="wayfinding" aria-label="Section shortcuts">
           <ul>
             <li><a href="#features">Features</a></li>
             <li><a href="#how-it-works">How it works</a></li>
@@ -142,15 +169,16 @@
         </nav>
 
         <div class="hero-content">
-          <p class="hero-eyebrow">
+          <p class="hero-eyebrow" data-intro="eyebrow">
             <img src="icon.svg" alt="" width="22" height="22" />
             <span>Wispr &middot; On-device dictation for macOS</span>
           </p>
           <h1 id="hero-heading">
-            Your voice, your words.<br />
-            <span class="instantly"> Instantly. </span>
+            <span class="line" data-intro="head1">Your voice, your words.</span
+            ><br />
+            <span class="instantly line" data-intro="head2"> Instantly. </span>
           </h1>
-          <div class="hero-cta">
+          <div class="hero-cta" data-intro="cta">
             <a class="btn btn-light" href="#download">Download for Mac</a>
             <a
               class="btn btn-glass"
@@ -181,7 +209,7 @@
           </div>
         </div>
 
-        <p class="hero-blurb">
+        <p class="hero-blurb" data-intro="blurb">
           Wispr listens on your Mac and nowhere else. On-device AI turns your
           speech into text in any app &mdash; no cloud, no accounts, and no
           audio ever leaving your machine. Free and open source.

--- a/website/index.html
+++ b/website/index.html
@@ -1,346 +1,848 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="a00255d5-c738-42aa-94bf-2834a28694c0"></script>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <script
+      defer
+      src="https://cloud.umami.is/script.js"
+      data-website-id="a00255d5-c738-42aa-94bf-2834a28694c0"
+    ></script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Wispr - Voice Dictation for Mac</title>
-    <meta name="description" content="Privacy-first voice dictation for macOS. Speak naturally, type effortlessly. All processing happens on your Mac with on-device AI.">
-    
+    <meta
+      name="description"
+      content="Privacy-first voice dictation for macOS. Speak naturally, type effortlessly. All processing happens on your Mac with on-device AI."
+    />
+
     <!-- Open Graph / Facebook / LinkedIn -->
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://wispr.stormacq.com/">
-    <meta property="og:title" content="Wispr - Voice Dictation for Mac">
-    <meta property="og:description" content="Privacy-first voice dictation for macOS. Speak naturally, type effortlessly. All processing happens on your Mac with on-device AI.">
-    <meta property="og:image" content="https://wispr.stormacq.com/og-image.png">
-    <meta property="og:image:alt" content="Wispr Logo">
-    <meta property="og:site_name" content="Wispr">
-    <meta property="og:locale" content="en_US">
-    
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://wispr.stormacq.com/" />
+    <meta property="og:title" content="Wispr - Voice Dictation for Mac" />
+    <meta
+      property="og:description"
+      content="Privacy-first voice dictation for macOS. Speak naturally, type effortlessly. All processing happens on your Mac with on-device AI."
+    />
+    <meta
+      property="og:image"
+      content="https://wispr.stormacq.com/og-image.png"
+    />
+    <meta property="og:image:alt" content="Wispr Logo" />
+    <meta property="og:site_name" content="Wispr" />
+    <meta property="og:locale" content="en_US" />
+
     <!-- Twitter / X -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:url" content="https://wispr.stormacq.com/">
-    <meta name="twitter:title" content="Wispr - Voice Dictation for Mac">
-    <meta name="twitter:description" content="Privacy-first voice dictation for macOS. Speak naturally, type effortlessly. All processing happens on your Mac with on-device AI.">
-    <meta name="twitter:image" content="https://wispr.stormacq.com/og-image.png">
-    <meta name="twitter:image:alt" content="Wispr Logo">
-    
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:url" content="https://wispr.stormacq.com/" />
+    <meta name="twitter:title" content="Wispr - Voice Dictation for Mac" />
+    <meta
+      name="twitter:description"
+      content="Privacy-first voice dictation for macOS. Speak naturally, type effortlessly. All processing happens on your Mac with on-device AI."
+    />
+    <meta
+      name="twitter:image"
+      content="https://wispr.stormacq.com/og-image.png"
+    />
+    <meta name="twitter:image:alt" content="Wispr Logo" />
+
     <!-- Additional Meta Tags -->
-    <meta name="author" content="Wispr">
-    <meta name="keywords" content="voice dictation, macOS, privacy, speech to text, whisper AI, parakeet AI, nvidia, offline transcription, voice typing">
-    <link rel="canonical" href="https://wispr.stormacq.com/">
-    
+    <meta name="author" content="Wispr" />
+    <meta
+      name="keywords"
+      content="voice dictation, macOS, privacy, speech to text, whisper AI, parakeet AI, nvidia, offline transcription, voice typing"
+    />
+    <link rel="canonical" href="https://wispr.stormacq.com/" />
+
     <!-- Favicon -->
-    <link rel="icon" type="image/svg+xml" href="icon.svg">
-    
-    <link rel="stylesheet" href="styles.css">
-</head>
-<body>
-    <!-- Hero Section -->
-    <section class="section hero">
-        <div class="container">
-            <img src="icon.svg" alt="Wispr Logo" class="logo">
-            <h1>Wispr</h1>
-            <p class="tagline">Your voice, your words. Instantly.</p>
-            <p class="subtitle">Privacy-first voice dictation for macOS. All processing happens on your Mac.</p>
-            <div class="hero-cta-group">
-                <a href="#download" class="cta-button primary">Download Now</a>
-                <a href="https://revolut.me/sbastiwm7" target="_blank" rel="noopener noreferrer" class="cta-button secondary">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
-                    </svg>
-                    Support
-                </a>
-            </div>
+    <link rel="icon" type="image/svg+xml" href="icon.svg" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&family=Space+Grotesk:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
+
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body id="top">
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <div class="header-inner">
+        <a href="#top" class="brand">
+          <img src="icon.svg" alt="" width="28" height="28" />
+          <span>Wispr</span>
+        </a>
+        <nav class="primary-nav" aria-label="Primary">
+          <a href="#features">Features</a>
+          <a href="#how-it-works">How it works</a>
+          <a href="#screenshots">Screenshots</a>
+          <a href="#support">Support</a>
+        </nav>
+        <div class="header-actions">
+          <a
+            class="ghost-link"
+            href="https://github.com/sebsto/wispr"
+            target="_blank"
+            rel="noopener noreferrer"
+            >GitHub</a
+          >
+          <a class="btn btn-light btn-sm" href="#download">Download</a>
         </div>
-        <div class="scroll-indicator">
-            <span>Scroll to explore</span>
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <polyline points="6 9 12 15 18 9"></polyline>
-            </svg>
+      </div>
+    </header>
+
+    <main id="main">
+      <!-- 1. Hero -->
+      <section class="section hero" aria-labelledby="hero-heading">
+        <div class="hero-glow" aria-hidden="true">
+          <div class="glow-blob glow-blob-a"></div>
+          <div class="glow-blob glow-blob-b"></div>
+          <div class="glow-blob glow-blob-c"></div>
         </div>
-    </section>
-
-    <!-- Download/Install Section -->
-    <section id="download" class="section download-section">
-        <div class="container">
-            <div class="download-grid">
-                <div class="download-card install-card">
-                    <div class="card-icon">
-                        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-                            <polyline points="7 10 12 15 17 10"></polyline>
-                            <line x1="12" y1="15" x2="12" y2="3"></line>
-                        </svg>
-                    </div>
-                    <h2>Get Started</h2>
-                    <p class="card-subtitle">Two easy ways to install Wispr</p>
-
-                    <div class="install-option">
-                        <a href="https://github.com/sebsto/wispr/releases/latest/download/Wispr.pkg" id="pkg-download-link" download class="download-button">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-                                <polyline points="7 10 12 15 17 10"></polyline>
-                                <line x1="12" y1="15" x2="12" y2="3"></line>
-                            </svg>
-                            <span id="pkg-download-text">Download the .pkg installer</span>
-                        </a>
-                        <p class="version-info" id="version-info">Loading version...</p>
-                    </div>
-
-                    <div class="install-divider"><span>or install with Homebrew</span></div>
-
-                    <div class="install-steps">
-                        <div class="code-block">
-                            <code>brew tap sebsto/macos</code>
-                            <button type="button" class="copy-btn" data-copy="brew tap sebsto/macos">Copy</button>
-                        </div>
-                        <div class="code-block">
-                            <code>brew install wispr</code>
-                            <button type="button" class="copy-btn" data-copy="brew install wispr">Copy</button>
-                        </div>
-                    </div>
-                </div>
-                
-                <div class="download-card donate-card">
-                    <div class="card-icon heart-icon">
-                        <svg width="48" height="48" viewBox="0 0 24 24" fill="currentColor" stroke="currentColor" stroke-width="2">
-                            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
-                        </svg>
-                    </div>
-                    <h2>Support Wispr</h2>
-                    <p class="card-subtitle">Help keep it free and open source</p>
-                    <div class="donate-benefits">
-                        <div class="benefit">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <polyline points="20 6 9 17 4 12"></polyline>
-                            </svg>
-                            <span>Support ongoing development</span>
-                        </div>
-                        <div class="benefit">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <polyline points="20 6 9 17 4 12"></polyline>
-                            </svg>
-                            <span>Keep Wispr free for everyone</span>
-                        </div>
-                        <div class="benefit">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <polyline points="20 6 9 17 4 12"></polyline>
-                            </svg>
-                            <span>Fund new features</span>
-                        </div>
-                    </div>
-                    <div class="card-bottom">
-                        <a href="https://revolut.me/sbastiwm7" target="_blank" rel="noopener noreferrer" class="donate-button-large">
-                            <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
-                            </svg>
-                            Donate
-                        </a>
-                        <p class="donate-note">Every contribution helps</p>
-                    </div>
-                </div>
-            </div>
+        <div class="hero-crosshair" aria-hidden="true">
+          <span class="crosshair-h"></span>
+          <span class="crosshair-v"></span>
+          <span class="crosshair-diag"></span>
         </div>
-    </section>
 
-    <!-- Features Section -->
-    <section id="features" class="section features">
-        <div class="container">
-            <h2>Speak naturally, type effortlessly</h2>
-            <div class="feature-grid">
-                <div class="feature-card">
-                    <div class="feature-icon">🎤</div>
-                    <h3>Global Hotkey</h3>
-                    <p>Press Option+Space anywhere on your Mac to start dictating. Release to transcribe. It's that simple.</p>
-                </div>
-                <div class="feature-card">
-                    <div class="feature-icon">🔒</div>
-                    <h3>100% Private</h3>
-                    <p>All voice processing happens on your device. No audio ever leaves your Mac. No cloud, no servers, no tracking.</p>
-                </div>
-                <div class="feature-card">
-                    <div class="feature-icon">⚡</div>
-                    <h3>Lightning Fast</h3>
-                    <p>Powered by on-device AI models including Whisper and NVIDIA Parakeet. Get accurate transcriptions in seconds, even without internet.</p>
-                </div>
-                <div class="feature-card">
-                    <div class="feature-icon">🌍</div>
-                    <h3>97 Languages</h3>
-                    <p>Dictate in any language. Auto-detect mode figures out what you're speaking, or pin your preferred language.</p>
-                </div>
-            </div>
-        </div>
-    </section>
+        <nav class="hero-wayfinding" aria-label="Section shortcuts">
+          <ul>
+            <li><a href="#features">Features</a></li>
+            <li><a href="#how-it-works">How it works</a></li>
+            <li><a href="#onboarding">Onboarding</a></li>
+            <li><a href="#screenshots">Screenshots</a></li>
+            <li><a href="#use-cases">Use cases</a></li>
+          </ul>
+          <ul>
+            <li><a href="#download">Download</a></li>
+            <li><a href="#download">Homebrew</a></li>
+            <li>
+              <a
+                href="https://github.com/sebsto/wispr"
+                target="_blank"
+                rel="noopener noreferrer"
+                >GitHub</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://revolut.me/sbastiwm7"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Donate</a
+              >
+            </li>
+          </ul>
+        </nav>
 
-    <!-- How It Works Section -->
-    <section class="section how-it-works">
-        <div class="container">
-            <h2>Three steps to better writing</h2>
-            <div class="steps">
-                <div class="step">
-                    <div class="step-number">1</div>
-                    <h3>Hold the hotkey</h3>
-                    <p>Press and hold Option+Space (or your custom shortcut) from any app.</p>
-                </div>
-                <div class="step">
-                    <div class="step-number">2</div>
-                    <h3>Speak your mind</h3>
-                    <p>Talk naturally. Wispr captures your voice and shows real-time audio feedback.</p>
-                </div>
-                <div class="step">
-                    <div class="step-number">3</div>
-                    <h3>Get instant text</h3>
-                    <p>Release the hotkey. Your words appear right where your cursor is.</p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Onboarding Section -->
-    <section class="section onboarding">
-        <div class="container">
-            <h2>Get started in minutes</h2>
-            <p class="section-subtitle">A guided setup walks you through everything you need.</p>
-            <div class="onboarding-carousel">
-                <div class="carousel-container">
-                    <div class="carousel-track">
-                        <div class="onboarding-slide">
-                            <img src="screenshots/onboarding-01.png" alt="Welcome to Wispr">
-                            <div class="slide-caption">
-                                <span class="slide-number">1</span>
-                                <p>Welcome to Wispr</p>
-                            </div>
-                        </div>
-                        <div class="onboarding-slide">
-                            <img src="screenshots/onboarding-02.png" alt="Grant microphone access">
-                            <div class="slide-caption">
-                                <span class="slide-number">2</span>
-                                <p>Grant microphone access</p>
-                            </div>
-                        </div>
-                        <div class="onboarding-slide">
-                            <img src="screenshots/onboarding-03.png" alt="Enable accessibility">
-                            <div class="slide-caption">
-                                <span class="slide-number">3</span>
-                                <p>Enable accessibility for text insertion</p>
-                            </div>
-                        </div>
-                        <div class="onboarding-slide">
-                            <img src="screenshots/onboarding-04.png" alt="Download the Parakeet AI model">
-                            <div class="slide-caption">
-                                <span class="slide-number">4</span>
-                                <p>Download the Parakeet AI model</p>
-                            </div>
-                        </div>
-                        <div class="onboarding-slide">
-                            <img src="screenshots/onboarding-05.png" alt="Test your setup">
-                            <div class="slide-caption">
-                                <span class="slide-number">5</span>
-                                <p>Test your setup with a quick dictation</p>
-                            </div>
-                        </div>
-                        <div class="onboarding-slide">
-                            <img src="screenshots/onboarding-06.png" alt="Ready to use">
-                            <div class="slide-caption">
-                                <span class="slide-number">6</span>
-                                <p>You're all set!</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="carousel-controls">
-                    <button class="carousel-btn prev" aria-label="Previous slide">
-                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <polyline points="15 18 9 12 15 6"></polyline>
-                        </svg>
-                    </button>
-                    <div class="carousel-dots"></div>
-                    <button class="carousel-btn next" aria-label="Next slide">
-                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <polyline points="9 18 15 12 9 6"></polyline>
-                        </svg>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Screenshots Section -->
-    <section class="section screenshots">
-        <div class="container">
-            <h2>Designed for macOS</h2>
-            <p class="section-subtitle">Clean, native interface that feels right at home on your Mac.</p>
-            <div class="screenshot-grid">
-                <div class="screenshot-item">
-                    <img src="screenshots/menu.png" alt="Menu bar interface">
-                    <p>Lives quietly in your menu bar</p>
-                </div>
-                <div class="screenshot-item">
-                    <img src="screenshots/settings.png" alt="Settings panel">
-                    <p>Customize to your workflow</p>
-                </div>
-                <div class="screenshot-item">
-                    <img src="screenshots/model-management.png" alt="Model management with Whisper and Parakeet">
-                    <p>Choose between Whisper and Parakeet models</p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Use Cases Section -->
-    <section class="section use-cases">
-        <div class="container">
-            <h2>Built for how you work</h2>
-            <div class="use-case-grid">
-                <div class="use-case">
-                    <h3>Writers</h3>
-                    <p>Draft articles, emails, and documents faster than typing. Let your thoughts flow without keyboard friction.</p>
-                </div>
-                <div class="use-case">
-                    <h3>Developers</h3>
-                    <p>Document code, write commit messages, and respond to issues using your voice. Works in any text field.</p>
-                </div>
-                <div class="use-case">
-                    <h3>Students</h3>
-                    <p>Take notes during lectures, write essays, and capture ideas quickly. Perfect for research and study sessions.</p>
-                </div>
-                <div class="use-case">
-                    <h3>Everyone</h3>
-                    <p>Reply to messages, fill forms, search the web. Anywhere you type, Wispr makes it faster.</p>
-                </div>
-            </div>
-        </div>
-    </section>
-
-    <!-- Support Section -->
-    <section class="section support">
-        <div class="container">
-            <h2>Love Wispr?</h2>
-            <p class="support-text">Your support keeps Wispr free, open source, and privacy-focused for everyone.</p>
-            <a href="https://revolut.me/sbastiwm7" target="_blank" rel="noopener noreferrer" class="donate-button">
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
-                </svg>
-                Support
+        <div class="hero-content">
+          <p class="hero-eyebrow">
+            <img src="icon.svg" alt="" width="22" height="22" />
+            <span>Wispr &middot; On-device dictation for macOS</span>
+          </p>
+          <h1 id="hero-heading">Your voice, your words.<br />Instantly.</h1>
+          <div class="hero-cta">
+            <a class="btn btn-light" href="#download">Download for Mac</a>
+            <a
+              class="btn btn-glass"
+              href="https://revolut.me/sbastiwm7"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span class="chip-stack" aria-hidden="true">
+                <span class="chip"
+                  ><img src="icon.svg" alt="" width="18" height="18"
+                /></span>
+                <span class="chip chip-heart">
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
+                    />
+                  </svg>
+                </span>
+              </span>
+              Support the project
             </a>
+          </div>
         </div>
-    </section>
 
-    <!-- Footer -->
-    <footer class="footer">
+        <p class="hero-blurb">
+          Wispr listens on your Mac and nowhere else. On-device AI turns your
+          speech into text in any app &mdash; no cloud, no accounts, and no
+          audio ever leaving your machine. Free and open source.
+        </p>
+
+        <figure class="hero-preview">
+          <img
+            src="screenshots/menu.png"
+            width="718"
+            height="434"
+            alt="Preview of the Wispr menu bar interface on macOS"
+          />
+        </figure>
+      </section>
+
+      <!-- 2. Download / Install -->
+      <section
+        id="download"
+        class="section download-section"
+        aria-labelledby="download-heading"
+      >
         <div class="container">
-            <p>&copy; 2026 Wispr. Built with care for macOS.</p>
-            <p class="footer-links">
-                <a href="https://github.com/sebsto/wispr" target="_blank" rel="noopener noreferrer">GitHub</a>
-                <span>•</span>
-                <a href="https://revolut.me/sbastiwm7" target="_blank" rel="noopener noreferrer">Donate</a>
-                <span>•</span>
-                <a href="https://github.com/sebsto/wispr/releases/latest" target="_blank" rel="noopener noreferrer">Download</a>
-            </p>
+          <p class="section-eyebrow">01 &middot; Install</p>
+          <h2 id="download-heading">Get Wispr</h2>
+          <p class="section-subtitle">
+            Two easy ways to install. Runs on Apple Silicon Macs.
+          </p>
+
+          <div class="download-grid">
+            <div class="panel install-card">
+              <h3>Download</h3>
+              <p class="panel-subtitle">
+                Signed and notarized installer, straight from GitHub.
+              </p>
+              <a
+                href="https://github.com/sebsto/wispr/releases/latest/download/Wispr.pkg"
+                id="pkg-download-link"
+                download
+                class="btn btn-light btn-block"
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                  <polyline points="7 10 12 15 17 10" />
+                  <line x1="12" y1="15" x2="12" y2="3" />
+                </svg>
+                <span id="pkg-download-text">Download the .pkg installer</span>
+              </a>
+              <p class="version-info" id="version-info">
+                Latest release on GitHub
+              </p>
+
+              <div class="install-divider" role="separator">
+                <span>or install with Homebrew</span>
+              </div>
+
+              <div class="code-block">
+                <code>brew tap sebsto/macos</code>
+                <button
+                  type="button"
+                  class="copy-btn"
+                  data-copy="brew tap sebsto/macos"
+                >
+                  Copy
+                </button>
+              </div>
+              <div class="code-block">
+                <code>brew install wispr</code>
+                <button
+                  type="button"
+                  class="copy-btn"
+                  data-copy="brew install wispr"
+                >
+                  Copy
+                </button>
+              </div>
+            </div>
+
+            <div class="panel donate-card">
+              <h3>Support Wispr</h3>
+              <p class="panel-subtitle">Help keep it free and open source.</p>
+              <ul class="benefit-list">
+                <li>
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                  Support ongoing development
+                </li>
+                <li>
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                  Keep Wispr free for everyone
+                </li>
+                <li>
+                  <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                  Fund new features
+                </li>
+              </ul>
+              <a
+                href="https://revolut.me/sbastiwm7"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="btn btn-glass btn-block"
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
+                  />
+                </svg>
+                Donate
+              </a>
+              <p class="donate-note">Every contribution helps</p>
+            </div>
+          </div>
         </div>
+      </section>
+
+      <!-- 3. Features -->
+      <section
+        id="features"
+        class="section features"
+        aria-labelledby="features-heading"
+      >
+        <div class="container">
+          <p class="section-eyebrow">02 &middot; Features</p>
+          <h2 id="features-heading">Speak naturally, type effortlessly</h2>
+          <div class="feature-grid">
+            <article class="feature-card reveal">
+              <div class="feature-icon" aria-hidden="true">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"
+                  />
+                  <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+                  <line x1="12" y1="19" x2="12" y2="23" />
+                  <line x1="8" y1="23" x2="16" y2="23" />
+                </svg>
+              </div>
+              <h3>Global hotkey</h3>
+              <p>
+                Press Option+Space anywhere on your Mac to start dictating.
+                Release to transcribe. It's that simple.
+              </p>
+            </article>
+            <article class="feature-card reveal">
+              <div class="feature-icon" aria-hidden="true">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                  <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                </svg>
+              </div>
+              <h3>100% private</h3>
+              <p>
+                All voice processing happens on your device. No audio ever
+                leaves your Mac. No cloud, no servers, no tracking.
+              </p>
+            </article>
+            <article class="feature-card reveal">
+              <div class="feature-icon" aria-hidden="true">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+                </svg>
+              </div>
+              <h3>Lightning fast</h3>
+              <p>
+                Powered by on-device AI models including Whisper and NVIDIA
+                Parakeet. Get accurate transcriptions in seconds, even without
+                internet.
+              </p>
+            </article>
+            <article class="feature-card reveal">
+              <div class="feature-icon" aria-hidden="true">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <line x1="2" y1="12" x2="22" y2="12" />
+                  <path
+                    d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
+                  />
+                </svg>
+              </div>
+              <h3>97 languages</h3>
+              <p>
+                Dictate in any language. Auto-detect mode figures out what
+                you're speaking, or pin your preferred language.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <!-- 4. How It Works -->
+      <section
+        id="how-it-works"
+        class="section how-it-works"
+        aria-labelledby="how-heading"
+      >
+        <div class="container">
+          <p class="section-eyebrow">03 &middot; How it works</p>
+          <h2 id="how-heading">Three steps to better writing</h2>
+          <ol class="steps">
+            <li class="step reveal">
+              <span class="step-number" aria-hidden="true">01</span>
+              <h3>Hold the hotkey</h3>
+              <p>
+                Press and hold Option+Space (or your custom shortcut) from any
+                app.
+              </p>
+            </li>
+            <li class="step reveal">
+              <span class="step-number" aria-hidden="true">02</span>
+              <h3>Speak your mind</h3>
+              <p>
+                Talk naturally. Wispr captures your voice and shows real-time
+                audio feedback.
+              </p>
+            </li>
+            <li class="step reveal">
+              <span class="step-number" aria-hidden="true">03</span>
+              <h3>Get instant text</h3>
+              <p>
+                Release the hotkey. Your words appear right where your cursor
+                is.
+              </p>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      <!-- 5. Onboarding -->
+      <section
+        id="onboarding"
+        class="section onboarding"
+        aria-labelledby="onboarding-heading"
+      >
+        <div class="container">
+          <p class="section-eyebrow">04 &middot; Onboarding</p>
+          <h2 id="onboarding-heading">Get started in minutes</h2>
+          <p class="section-subtitle">
+            A guided setup walks you through everything you need.
+          </p>
+
+          <div
+            class="carousel"
+            role="group"
+            aria-roledescription="carousel"
+            aria-label="Onboarding walkthrough"
+          >
+            <div
+              class="carousel-viewport"
+              tabindex="0"
+              aria-label="Onboarding steps. Use the left and right arrow keys to change slides."
+            >
+              <ul class="carousel-track">
+                <li
+                  class="carousel-slide"
+                  role="group"
+                  aria-roledescription="slide"
+                  aria-label="Step 1 of 6"
+                >
+                  <figure>
+                    <img
+                      src="screenshots/onboarding-01.png"
+                      width="712"
+                      height="644"
+                      alt="Wispr onboarding: welcome screen"
+                      loading="lazy"
+                    />
+                    <figcaption>
+                      <span class="slide-number" aria-hidden="true">1</span
+                      >Welcome to Wispr
+                    </figcaption>
+                  </figure>
+                </li>
+                <li
+                  class="carousel-slide"
+                  role="group"
+                  aria-roledescription="slide"
+                  aria-label="Step 2 of 6"
+                >
+                  <figure>
+                    <img
+                      src="screenshots/onboarding-02.png"
+                      width="712"
+                      height="644"
+                      alt="Wispr onboarding: grant microphone access"
+                      loading="lazy"
+                    />
+                    <figcaption>
+                      <span class="slide-number" aria-hidden="true">2</span
+                      >Grant microphone access
+                    </figcaption>
+                  </figure>
+                </li>
+                <li
+                  class="carousel-slide"
+                  role="group"
+                  aria-roledescription="slide"
+                  aria-label="Step 3 of 6"
+                >
+                  <figure>
+                    <img
+                      src="screenshots/onboarding-03.png"
+                      width="712"
+                      height="644"
+                      alt="Wispr onboarding: enable accessibility permission for text insertion"
+                      loading="lazy"
+                    />
+                    <figcaption>
+                      <span class="slide-number" aria-hidden="true">3</span
+                      >Enable accessibility for text insertion
+                    </figcaption>
+                  </figure>
+                </li>
+                <li
+                  class="carousel-slide"
+                  role="group"
+                  aria-roledescription="slide"
+                  aria-label="Step 4 of 6"
+                >
+                  <figure>
+                    <img
+                      src="screenshots/onboarding-04.png"
+                      width="1424"
+                      height="1288"
+                      alt="Wispr onboarding: download the Parakeet AI model"
+                      loading="lazy"
+                    />
+                    <figcaption>
+                      <span class="slide-number" aria-hidden="true">4</span
+                      >Download the Parakeet AI model
+                    </figcaption>
+                  </figure>
+                </li>
+                <li
+                  class="carousel-slide"
+                  role="group"
+                  aria-roledescription="slide"
+                  aria-label="Step 5 of 6"
+                >
+                  <figure>
+                    <img
+                      src="screenshots/onboarding-05.png"
+                      width="712"
+                      height="644"
+                      alt="Wispr onboarding: test your setup with a quick dictation"
+                      loading="lazy"
+                    />
+                    <figcaption>
+                      <span class="slide-number" aria-hidden="true">5</span>Test
+                      your setup with a quick dictation
+                    </figcaption>
+                  </figure>
+                </li>
+                <li
+                  class="carousel-slide"
+                  role="group"
+                  aria-roledescription="slide"
+                  aria-label="Step 6 of 6"
+                >
+                  <figure>
+                    <img
+                      src="screenshots/onboarding-06.png"
+                      width="712"
+                      height="644"
+                      alt="Wispr onboarding: setup complete, ready to use"
+                      loading="lazy"
+                    />
+                    <figcaption>
+                      <span class="slide-number" aria-hidden="true">6</span
+                      >You're all set!
+                    </figcaption>
+                  </figure>
+                </li>
+              </ul>
+            </div>
+            <div class="carousel-controls">
+              <button
+                type="button"
+                class="carousel-btn prev"
+                aria-label="Previous slide"
+              >
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="15 18 9 12 15 6" />
+                </svg>
+              </button>
+              <div class="carousel-dots"></div>
+              <button
+                type="button"
+                class="carousel-btn next"
+                aria-label="Next slide"
+              >
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <polyline points="9 18 15 12 9 6" />
+                </svg>
+              </button>
+            </div>
+            <p
+              class="visually-hidden"
+              aria-live="polite"
+              id="carousel-status"
+            ></p>
+          </div>
+        </div>
+      </section>
+
+      <!-- 6. Screenshots -->
+      <section
+        id="screenshots"
+        class="section screenshots"
+        aria-labelledby="screenshots-heading"
+      >
+        <div class="container">
+          <p class="section-eyebrow">05 &middot; Screenshots</p>
+          <h2 id="screenshots-heading">Designed for macOS</h2>
+          <p class="section-subtitle">
+            Clean, native interface that feels right at home on your Mac.
+          </p>
+          <div class="screenshot-grid">
+            <figure class="screenshot-item shot-menu reveal">
+              <img
+                src="screenshots/menu.png"
+                width="718"
+                height="434"
+                alt="Wispr menu bar interface"
+                loading="lazy"
+              />
+              <figcaption>Lives quietly in your menu bar</figcaption>
+            </figure>
+            <figure class="screenshot-item shot-settings reveal">
+              <img
+                src="screenshots/settings.png"
+                width="1264"
+                height="1510"
+                alt="Wispr settings panel"
+                loading="lazy"
+              />
+              <figcaption>Customize to your workflow</figcaption>
+            </figure>
+            <figure class="screenshot-item shot-models reveal">
+              <img
+                src="screenshots/model-management.png"
+                width="1464"
+                height="1568"
+                alt="Wispr model management with Whisper and Parakeet models"
+                loading="lazy"
+              />
+              <figcaption>
+                Choose between Whisper and Parakeet models
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <!-- 7. Use Cases -->
+      <section
+        id="use-cases"
+        class="section use-cases"
+        aria-labelledby="use-cases-heading"
+      >
+        <div class="container">
+          <p class="section-eyebrow">06 &middot; Use cases</p>
+          <h2 id="use-cases-heading">Built for how you work</h2>
+          <div class="use-case-grid">
+            <article class="use-case reveal">
+              <h3>Writers</h3>
+              <p>
+                Draft articles, emails, and documents faster than typing. Let
+                your thoughts flow without keyboard friction.
+              </p>
+            </article>
+            <article class="use-case reveal">
+              <h3>Developers</h3>
+              <p>
+                Document code, write commit messages, and respond to issues
+                using your voice. Works in any text field.
+              </p>
+            </article>
+            <article class="use-case reveal">
+              <h3>Students</h3>
+              <p>
+                Take notes during lectures, write essays, and capture ideas
+                quickly. Perfect for research and study sessions.
+              </p>
+            </article>
+            <article class="use-case reveal">
+              <h3>Everyone</h3>
+              <p>
+                Reply to messages, fill forms, search the web. Anywhere you
+                type, Wispr makes it faster.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <!-- 8. Support -->
+      <section
+        id="support"
+        class="section support"
+        aria-labelledby="support-heading"
+      >
+        <div class="support-glow" aria-hidden="true"></div>
+        <div class="container">
+          <p class="section-eyebrow">07 &middot; Support</p>
+          <h2 id="support-heading">Love Wispr?</h2>
+          <p class="support-text">
+            Your support keeps Wispr free, open source, and privacy-focused for
+            everyone.
+          </p>
+          <a
+            href="https://revolut.me/sbastiwm7"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="btn btn-light"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
+              />
+            </svg>
+            Donate via Revolut
+          </a>
+        </div>
+      </section>
+    </main>
+
+    <!-- 9. Footer -->
+    <footer class="footer">
+      <div class="container footer-inner">
+        <a href="#top" class="brand brand-footer">
+          <img src="icon.svg" alt="" width="24" height="24" />
+          <span>Wispr</span>
+        </a>
+        <nav class="footer-links" aria-label="Footer">
+          <a
+            href="https://github.com/sebsto/wispr"
+            target="_blank"
+            rel="noopener noreferrer"
+            >GitHub</a
+          >
+          <a
+            href="https://revolut.me/sbastiwm7"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Donate</a
+          >
+          <a
+            href="https://github.com/sebsto/wispr/releases/latest"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Download</a
+          >
+        </nav>
+        <p class="footer-copy">&copy; 2026 Wispr. Built with care for macOS.</p>
+      </div>
     </footer>
 
     <script src="script.js"></script>
-</body>
+  </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -96,6 +96,10 @@
     <main id="main">
       <!-- 1. Hero -->
       <section class="section hero" aria-labelledby="hero-heading">
+        <!-- Animated wave field (WebGL2, see waves.js). The CSS glow that
+             follows is the fallback shown when WebGL2 or JS is unavailable. -->
+        <div class="hero-waves" aria-hidden="true"></div>
+        <div class="hero-scrim" aria-hidden="true"></div>
         <div class="hero-glow" aria-hidden="true">
           <div class="glow-blob glow-blob-a"></div>
           <div class="glow-blob glow-blob-b"></div>
@@ -179,15 +183,6 @@
           speech into text in any app &mdash; no cloud, no accounts, and no
           audio ever leaving your machine. Free and open source.
         </p>
-
-        <figure class="hero-preview">
-          <img
-            src="screenshots/menu.png"
-            width="718"
-            height="434"
-            alt="Preview of the Wispr menu bar interface on macOS"
-          />
-        </figure>
       </section>
 
       <!-- 2. Download / Install -->
@@ -844,5 +839,6 @@
     </footer>
 
     <script src="script.js"></script>
+    <script src="waves.js"></script>
   </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -146,7 +146,10 @@
             <img src="icon.svg" alt="" width="22" height="22" />
             <span>Wispr &middot; On-device dictation for macOS</span>
           </p>
-          <h1 id="hero-heading">Your voice, your words.<br />Instantly.</h1>
+          <h1 id="hero-heading">
+            Your voice, your words.<br />
+            <span class="instantly"> Instantly. </span>
+          </h1>
           <div class="hero-cta">
             <a class="btn btn-light" href="#download">Download for Mac</a>
             <a

--- a/website/script.js
+++ b/website/script.js
@@ -337,3 +337,9 @@ if (prefersReducedMotion || !('IntersectionObserver' in window)) {
         settle('waves');
     }
 })();
+
+// Tells the failsafe in index.html's inline script that this file ran to
+// completion, so it leaves the armed curtain/reveal classes alone. Last line on
+// purpose: if anything above throws, the flag stays unset and the failsafe
+// un-arms the page instead of leaving the curtain or hidden sections stranded.
+document.documentElement.dataset.introReady = '1';

--- a/website/script.js
+++ b/website/script.js
@@ -239,3 +239,101 @@ if (prefersReducedMotion || !('IntersectionObserver' in window)) {
 
     updateUI();
 })();
+
+/* --------------------------------------------------------------------------
+   Load curtain & hero entrance
+
+   The curtain waits on real signals — fonts decoded, page loaded, first wave
+   frame painted — never a fixed delay. When they land (or the failsafe fires)
+   it lifts, and dropping .intro-armed plays every hero beat at once, each
+   offset by its own --intro-delay in styles.css. The same moment releases the
+   wave field's zoom spring, so the background motion and the copy arrive
+   together instead of one after the other.
+   -------------------------------------------------------------------------- */
+(function () {
+    const root = document.documentElement;
+
+    // The inline script in index.html only arms this when motion is welcome.
+    if (!root.classList.contains('intro-armed')) return;
+
+    const MIN_HOLD = 450;   // don't flash the curtain on a warm cache
+    const FAILSAFE = 1200;  // never let a stalled signal strand the page
+
+    let revealed = false;
+
+    function reveal() {
+        if (revealed) return;
+        revealed = true;
+        // Someone who scrolled while the curtain was up would otherwise watch
+        // the hero animate off-screen behind them, so skip straight to the end.
+        if (window.scrollY > 40) root.classList.add('intro-instant');
+        root.classList.remove('intro-armed');
+        document.dispatchEvent(new CustomEvent('wispr:reveal'));
+    }
+
+    const loader = document.querySelector('.loader');
+    if (!root.classList.contains('intro-loader') || !loader) {
+        // Already seen this session: keep the entrance, drop the curtain.
+        requestAnimationFrame(reveal);
+        return;
+    }
+
+    const fill = loader.querySelector('.loader-fill');
+    const started = performance.now();
+    const pending = new Set(['fonts', 'load', 'waves']);
+    const total = pending.size;
+    let lifted = false;
+    let failsafeTimer = 0;
+
+    function lift() {
+        if (lifted) return;
+        lifted = true;
+        clearTimeout(failsafeTimer);
+        if (fill) fill.style.width = '100%';
+        try {
+            sessionStorage.setItem('wispr-intro', '1');
+        } catch (e) { /* private mode — the curtain just shows again */ }
+
+        // Let the fill visibly reach the end before the curtain goes.
+        setTimeout(function () {
+            loader.classList.add('is-done');
+            reveal();
+            setTimeout(function () { loader.remove(); }, 260);
+        }, 80);
+    }
+
+    function settle(name) {
+        if (!pending.has(name)) return;
+        pending.delete(name);
+        if (fill) {
+            fill.style.width = Math.round(((total - pending.size) / total) * 100) + '%';
+        }
+        if (pending.size) return;
+        setTimeout(lift, Math.max(0, MIN_HOLD - (performance.now() - started)));
+    }
+
+    failsafeTimer = setTimeout(lift, FAILSAFE);
+
+    if (document.fonts && document.fonts.ready) {
+        document.fonts.ready.then(function () { settle('fonts'); });
+    } else {
+        settle('fonts');
+    }
+
+    if (document.readyState === 'complete') {
+        settle('load');
+    } else {
+        window.addEventListener('load', function () { settle('load'); }, { once: true });
+    }
+
+    // waves.js announces its first painted frame. If the hero has no canvas, or
+    // WebGL2 is unavailable so nothing ever announces, this resolves on load.
+    if (document.querySelector('.hero-waves')) {
+        document.addEventListener('wispr:waves-ready', function () { settle('waves'); }, { once: true });
+        window.addEventListener('load', function () {
+            setTimeout(function () { settle('waves'); }, 200);
+        }, { once: true });
+    } else {
+        settle('waves');
+    }
+})();

--- a/website/script.js
+++ b/website/script.js
@@ -1,23 +1,36 @@
-// Smooth scroll behavior for anchor links
-document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-    anchor.addEventListener('click', function (e) {
-        e.preventDefault();
-        const target = document.querySelector(this.getAttribute('href'));
-        if (target) {
-            target.scrollIntoView({
-                behavior: 'smooth',
-                block: 'start'
-            });
-        }
-    });
-});
+// Progressive enhancement marker: reveal-on-scroll styles only apply when JS runs,
+// so all content stays visible if this file fails to load.
+document.documentElement.classList.add('js');
 
-// Enrich the version label from the GitHub API. The download button itself is a
-// STATIC link to releases/latest/download/Wispr.pkg (set in the HTML), so the
-// download works even if this fetch fails/rate-limits — we only decorate the
-// version text and never touch the button's href.
+const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+/* --------------------------------------------------------------------------
+   Header: frosted background once the page is scrolled
+   -------------------------------------------------------------------------- */
+const header = document.querySelector('.site-header');
+let headerTicking = false;
+
+function updateHeader() {
+    if (header) header.classList.toggle('scrolled', window.scrollY > 8);
+    headerTicking = false;
+}
+
+window.addEventListener('scroll', () => {
+    if (!headerTicking) {
+        window.requestAnimationFrame(updateHeader);
+        headerTicking = true;
+    }
+}, { passive: true });
+updateHeader();
+
+/* --------------------------------------------------------------------------
+   Release version label. The download button is a STATIC link to
+   releases/latest/download/Wispr.pkg (set in the HTML), so downloads work even
+   if this fetch fails or rate-limits — we only decorate the version text.
+   -------------------------------------------------------------------------- */
 async function fetchLatestRelease() {
     const versionInfo = document.getElementById('version-info');
+    if (!versionInfo) return;
     try {
         const response = await fetch('https://api.github.com/repos/sebsto/wispr/releases/latest');
         if (!response.ok) {
@@ -28,295 +41,201 @@ async function fetchLatestRelease() {
         const pkg = (data.assets || []).find(a => a.name.endsWith('.pkg') && a.name !== 'Wispr.pkg')
             || (data.assets || []).find(a => a.name === 'Wispr.pkg');
 
-        if (versionInfo) {
-            versionInfo.textContent = pkg
-                ? `Latest: ${data.tag_name} • ${(pkg.size / 1024 / 1024).toFixed(1)} MB`
-                : `Latest: ${data.tag_name}`;
-        }
+        versionInfo.textContent = pkg
+            ? `Latest: ${data.tag_name} • ${(pkg.size / 1024 / 1024).toFixed(1)} MB`
+            : `Latest: ${data.tag_name}`;
     } catch (error) {
-        console.error('Failed to fetch latest release:', error);
-        // Leave the static button intact; just soften the version label.
-        if (versionInfo) versionInfo.textContent = 'Latest release on GitHub';
+        // Not an error condition for the page: the static label already links users
+        // to the latest release, so just note it quietly.
+        console.warn('Could not fetch latest release info:', error);
     }
 }
-
-// Copy to clipboard functionality
-document.querySelectorAll('.copy-btn').forEach(btn => {
-    btn.addEventListener('click', async function() {
-        const textToCopy = this.getAttribute('data-copy');
-        try {
-            await navigator.clipboard.writeText(textToCopy);
-            const originalText = this.textContent;
-            this.textContent = 'Copied!';
-            setTimeout(() => {
-                this.textContent = originalText;
-            }, 2000);
-        } catch (err) {
-            console.error('Failed to copy:', err);
-        }
-    });
-});
-
-// Call on page load
 fetchLatestRelease();
 
-// Intersection Observer for fade-in animations
-const observerOptions = {
-    threshold: 0.2,
-    rootMargin: '0px 0px -100px 0px'
-};
-
-const observer = new IntersectionObserver((entries) => {
-    entries.forEach(entry => {
-        if (entry.isIntersecting) {
-            entry.target.classList.add('visible');
+/* --------------------------------------------------------------------------
+   Copy-to-clipboard buttons (Homebrew commands)
+   -------------------------------------------------------------------------- */
+function copyText(text) {
+    if (navigator.clipboard && window.isSecureContext) {
+        return navigator.clipboard.writeText(text);
+    }
+    // Fallback for non-secure contexts (e.g. plain http)
+    return new Promise((resolve, reject) => {
+        const textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.setAttribute('readonly', '');
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        try {
+            document.execCommand('copy') ? resolve() : reject(new Error('execCommand copy failed'));
+        } catch (err) {
+            reject(err);
+        } finally {
+            textarea.remove();
         }
     });
-}, observerOptions);
+}
 
-// Observe all feature cards, steps, and use cases
-document.querySelectorAll('.feature-card, .step, .use-case, .screenshot-item').forEach(el => {
-    el.style.opacity = '0';
-    el.style.transform = 'translateY(30px)';
-    el.style.transition = 'opacity 0.6s ease, transform 0.6s ease';
-    observer.observe(el);
+document.querySelectorAll('.copy-btn').forEach(btn => {
+    btn.addEventListener('click', async function () {
+        const originalText = this.textContent;
+        try {
+            await copyText(this.getAttribute('data-copy'));
+            this.textContent = 'Copied!';
+            this.classList.add('copied');
+        } catch (err) {
+            console.warn('Copy to clipboard failed:', err);
+            this.textContent = 'Copy failed';
+        }
+        setTimeout(() => {
+            this.textContent = originalText;
+            this.classList.remove('copied');
+        }, 2000);
+    });
 });
 
-// Add visible class styling
-const style = document.createElement('style');
-style.textContent = `
-    .visible {
-        opacity: 1 !important;
-        transform: translateY(0) !important;
-    }
-`;
-document.head.appendChild(style);
+/* --------------------------------------------------------------------------
+   Scroll-reveal animations (staggered within each group)
+   -------------------------------------------------------------------------- */
+const revealEls = document.querySelectorAll('.reveal');
 
-// Add staggered animation delays
-document.querySelectorAll('.feature-card').forEach((card, index) => {
-    card.style.transitionDelay = `${index * 0.1}s`;
-});
+if (prefersReducedMotion || !('IntersectionObserver' in window)) {
+    revealEls.forEach(el => el.classList.add('is-visible'));
+} else {
+    revealEls.forEach(el => {
+        const siblings = el.parentElement
+            ? Array.from(el.parentElement.querySelectorAll(':scope > .reveal'))
+            : [el];
+        el.style.transitionDelay = `${(siblings.indexOf(el) % 4) * 0.08}s`;
+    });
 
-document.querySelectorAll('.step').forEach((step, index) => {
-    step.style.transitionDelay = `${index * 0.15}s`;
-});
+    const revealObserver = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('is-visible');
+                revealObserver.unobserve(entry.target);
+            }
+        });
+    }, { threshold: 0.15, rootMargin: '0px 0px -60px 0px' });
 
-document.querySelectorAll('.use-case').forEach((useCase, index) => {
-    useCase.style.transitionDelay = `${index * 0.1}s`;
-});
+    revealEls.forEach(el => revealObserver.observe(el));
+}
 
-document.querySelectorAll('.screenshot-item').forEach((item, index) => {
-    item.style.transitionDelay = `${index * 0.15}s`;
-});
+/* --------------------------------------------------------------------------
+   Onboarding carousel.
+   Built on native horizontal scroll + CSS scroll-snap, so swipe and trackpad
+   work with no JS at all; this script adds buttons, dots, keyboard support,
+   and a screen-reader status line.
+   -------------------------------------------------------------------------- */
+(function initCarousel() {
+    const viewport = document.querySelector('.carousel-viewport');
+    const slides = Array.from(document.querySelectorAll('.carousel-slide'));
+    const dotsContainer = document.querySelector('.carousel-dots');
+    const prevBtn = document.querySelector('.carousel-btn.prev');
+    const nextBtn = document.querySelector('.carousel-btn.next');
+    const status = document.getElementById('carousel-status');
 
-// Onboarding Carousel - Only initialize if elements exist
-const slides = document.querySelectorAll('.onboarding-slide');
-const track = document.querySelector('.carousel-track');
-const dotsContainer = document.querySelector('.carousel-dots');
-const prevBtn = document.querySelector('.carousel-btn.prev');
-const nextBtn = document.querySelector('.carousel-btn.next');
+    if (!viewport || slides.length === 0 || !dotsContainer || !prevBtn || !nextBtn) return;
 
-if (slides.length > 0 && track && dotsContainer && prevBtn && nextBtn) {
-    let currentSlide = 0;
     const totalSlides = slides.length;
+    let currentSlide = 0;
+    // While a smooth scroll is in flight, currentSlide lags behind; navigation
+    // is based on the pending target so rapid presses advance one slide each.
+    let pendingTarget = null;
 
-    // Create dots
-    for (let i = 0; i < totalSlides; i++) {
+    slides.forEach((_, i) => {
         const dot = document.createElement('button');
+        dot.type = 'button';
         dot.classList.add('carousel-dot');
-        if (i === 0) dot.classList.add('active');
-        dot.setAttribute('aria-label', `Go to slide ${i + 1}`);
+        dot.setAttribute('aria-label', `Go to step ${i + 1} of ${totalSlides}`);
         dot.addEventListener('click', () => goToSlide(i));
         dotsContainer.appendChild(dot);
+    });
+    const dots = Array.from(dotsContainer.children);
+
+    function updateUI() {
+        dots.forEach((dot, i) => {
+            dot.classList.toggle('active', i === currentSlide);
+            if (i === currentSlide) {
+                dot.setAttribute('aria-current', 'true');
+            } else {
+                dot.removeAttribute('aria-current');
+            }
+        });
+        prevBtn.disabled = currentSlide === 0;
+        nextBtn.disabled = currentSlide === totalSlides - 1;
+        if (status) {
+            const caption = slides[currentSlide].querySelector('figcaption');
+            // Only the caption's own text — skip the decorative slide-number badge
+            const captionText = caption
+                ? Array.from(caption.childNodes)
+                    .filter(node => node.nodeType === Node.TEXT_NODE)
+                    .map(node => node.textContent)
+                    .join('')
+                    .trim()
+                : '';
+            status.textContent = `Step ${currentSlide + 1} of ${totalSlides}${captionText ? ': ' + captionText : ''}`;
+        }
     }
 
-    const dots = document.querySelectorAll('.carousel-dot');
-
-    function updateCarousel() {
-        if (!track || slides.length === 0) return;
-        
-        const slideWidth = slides[0].offsetWidth;
-        const gap = 32; // 2rem gap
-        const offset = currentSlide * (slideWidth + gap);
-        track.style.transform = `translateX(-${offset}px)`;
-        
-        // Update dots
-        dots.forEach((dot, index) => {
-            dot.classList.toggle('active', index === currentSlide);
-        });
-        
-        // Update button states
-        if (prevBtn) prevBtn.disabled = currentSlide === 0;
-        if (nextBtn) nextBtn.disabled = currentSlide === totalSlides - 1;
+    function slideBase() {
+        return pendingTarget !== null ? pendingTarget : currentSlide;
     }
 
     function goToSlide(index) {
-        currentSlide = Math.max(0, Math.min(index, totalSlides - 1));
-        updateCarousel();
-    }
-
-    function nextSlide() {
-        if (currentSlide < totalSlides - 1) {
-            currentSlide++;
-            updateCarousel();
+        const target = Math.max(0, Math.min(index, totalSlides - 1));
+        pendingTarget = target;
+        const left = target * viewport.clientWidth;
+        try {
+            viewport.scrollTo({ left, behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+        } catch (err) {
+            viewport.scrollLeft = left;
         }
     }
 
-    function prevSlide() {
-        if (currentSlide > 0) {
-            currentSlide--;
-            updateCarousel();
-        }
-    }
-
-    prevBtn.addEventListener('click', prevSlide);
-    nextBtn.addEventListener('click', nextSlide);
-
-    // Track if carousel is in view for keyboard navigation
-    let carouselInView = false;
-    const carouselObserver = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-            carouselInView = entry.isIntersecting;
-        });
-    }, { threshold: 0.5 });
-
-    const carousel = document.querySelector('.onboarding-carousel');
-    if (carousel) {
-        carouselObserver.observe(carousel);
-    }
-
-    // Keyboard navigation for carousel (only when in view)
-    document.addEventListener('keydown', (e) => {
-        if (carouselInView && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
-            e.preventDefault();
-            if (e.key === 'ArrowLeft') {
-                prevSlide();
-            } else if (e.key === 'ArrowRight') {
-                nextSlide();
+    // Keep state in sync with native scrolling (swipe, trackpad, snap)
+    let scrollTicking = false;
+    viewport.addEventListener('scroll', () => {
+        if (scrollTicking) return;
+        scrollTicking = true;
+        window.requestAnimationFrame(() => {
+            const index = Math.round(viewport.scrollLeft / viewport.clientWidth);
+            if (index === pendingTarget) pendingTarget = null;
+            if (index !== currentSlide && index >= 0 && index < totalSlides) {
+                currentSlide = index;
+                updateUI();
             }
+            scrollTicking = false;
+        });
+    }, { passive: true });
+
+    prevBtn.addEventListener('click', () => goToSlide(slideBase() - 1));
+    nextBtn.addEventListener('click', () => goToSlide(slideBase() + 1));
+
+    // Arrow-key navigation while the carousel has focus
+    viewport.addEventListener('keydown', (e) => {
+        const actions = {
+            ArrowLeft: slideBase() - 1,
+            ArrowRight: slideBase() + 1,
+            Home: 0,
+            End: totalSlides - 1
+        };
+        if (e.key in actions) {
+            e.preventDefault();
+            goToSlide(actions[e.key]);
         }
     });
 
-    // Auto-advance carousel
-    let autoAdvanceInterval;
-    function startAutoAdvance() {
-        // Clear any existing interval before starting a new one
-        if (autoAdvanceInterval) {
-            clearInterval(autoAdvanceInterval);
-        }
-        autoAdvanceInterval = setInterval(() => {
-            if (currentSlide < totalSlides - 1) {
-                nextSlide();
-            } else {
-                currentSlide = 0;
-                updateCarousel();
-            }
-        }, 5000);
-    }
-
-    function stopAutoAdvance() {
-        if (autoAdvanceInterval) {
-            clearInterval(autoAdvanceInterval);
-            autoAdvanceInterval = null;
-        }
-    }
-
-    // Start/stop auto-advance based on visibility
-    const autoAdvanceObserver = new IntersectionObserver((entries) => {
-        entries.forEach(entry => {
-            if (entry.isIntersecting) {
-                startAutoAdvance();
-            } else {
-                stopAutoAdvance();
-            }
-        });
-    }, { threshold: 0.5 });
-
-    if (carousel) {
-        autoAdvanceObserver.observe(carousel);
-        carousel.addEventListener('click', stopAutoAdvance);
-        carousel.addEventListener('touchstart', stopAutoAdvance);
-    }
-
-    // Update carousel on window resize (throttled)
+    // Re-align the current slide after a resize changes the viewport width
     let resizeTimeout;
     window.addEventListener('resize', () => {
         clearTimeout(resizeTimeout);
-        resizeTimeout = setTimeout(updateCarousel, 150);
-    });
-}
-
-// Consolidated scroll handler with requestAnimationFrame throttling
-let scrollTicking = false;
-
-function handleScroll() {
-    const scrollY = window.scrollY;
-    
-    // Hide scroll indicator when user scrolls
-    const scrollIndicator = document.querySelector('.scroll-indicator');
-    if (scrollIndicator) {
-        if (scrollY > 100) {
-            scrollIndicator.style.opacity = '0';
-            scrollIndicator.style.pointerEvents = 'none';
-        } else {
-            scrollIndicator.style.opacity = '0.7';
-            scrollIndicator.style.pointerEvents = 'auto';
-        }
-    }
-    
-    // Parallax effect for hero background
-    const hero = document.querySelector('.hero');
-    if (hero) {
-        const heroHeight = hero.offsetHeight;
-        if (scrollY < heroHeight) {
-            hero.style.transform = `translateY(${scrollY * 0.5}px)`;
-            hero.style.opacity = 1 - (scrollY / heroHeight) * 0.5;
-        }
-    }
-    
-    scrollTicking = false;
-}
-
-window.addEventListener('scroll', () => {
-    if (!scrollTicking) {
-        window.requestAnimationFrame(handleScroll);
-        scrollTicking = true;
-    }
-});
-
-// Section keyboard navigation (only when carousel not in view)
-document.addEventListener('keydown', (e) => {
-    // Skip if carousel is in view
-    const carousel = document.querySelector('.onboarding-carousel');
-    if (carousel) {
-        const rect = carousel.getBoundingClientRect();
-        const carouselVisible = rect.top >= -100 && rect.top <= window.innerHeight;
-        if (carouselVisible) return;
-    }
-    
-    const sections = document.querySelectorAll('.section');
-    const currentSection = Array.from(sections).findIndex(section => {
-        const rect = section.getBoundingClientRect();
-        return rect.top >= -100 && rect.top <= 100;
+        resizeTimeout = setTimeout(() => {
+            viewport.scrollLeft = currentSlide * viewport.clientWidth;
+        }, 150);
     });
 
-    if (e.key === 'ArrowDown' && currentSection < sections.length - 1) {
-        e.preventDefault();
-        sections[currentSection + 1].scrollIntoView({ behavior: 'smooth' });
-    } else if (e.key === 'ArrowUp' && currentSection > 0) {
-        e.preventDefault();
-        sections[currentSection - 1].scrollIntoView({ behavior: 'smooth' });
-    }
-});
-
-// Add loading animation
-window.addEventListener('load', () => {
-    const computedOpacity = window.getComputedStyle(document.body).opacity;
-    // Only apply fade-in if the body was initially hidden via CSS (opacity 0)
-    if (computedOpacity === '0') {
-        document.body.style.transition = 'opacity 0.5s ease';
-        window.requestAnimationFrame(() => {
-            document.body.style.opacity = '1';
-        });
-    }
-});
+    updateUI();
+})();

--- a/website/styles.css
+++ b/website/styles.css
@@ -1223,10 +1223,13 @@ a {
 }
 
 /* ==========================================================================
-   Scroll reveal (activated by script.js; content stays visible without JS)
+   Scroll reveal
+   Gated on .reveal-armed, which the inline script in index.html sets and drops
+   again if script.js never checks in -- so content is visible both without JS
+   and when script.js fails to load.
    ========================================================================== */
 
-.js .reveal {
+.reveal-armed .reveal {
   opacity: 0;
   transform: translateY(24px);
   transition:
@@ -1234,7 +1237,7 @@ a {
     transform 0.6s ease;
 }
 
-.js .reveal.is-visible {
+.reveal-armed .reveal.is-visible {
   opacity: 1;
   transform: none;
 }
@@ -1341,7 +1344,9 @@ a {
     transition-duration: 0.01ms !important;
   }
 
-  .js .reveal {
+  /* Covers a reduced-motion preference switched on after load, when the class
+     is already armed. */
+  .reveal-armed .reveal {
     opacity: 1;
     transform: none;
   }

--- a/website/styles.css
+++ b/website/styles.css
@@ -273,11 +273,11 @@ a {
 .instantly {
   font-style: italic;
   /* color: #f5f6f816; */
-  color: #f5f6f8;
+  color: #5c88d9ae;
 
-  text-shadow: 4px 0px 0px rgb(0, 122, 252);
+  text-shadow: 3px 3px 0px rgb(0, 122, 252);
 
-  /* -webkit-text-stroke: 1px #f5f6f8a2; Thickness and color of the border */
+  -webkit-text-stroke: 2px #dcdcdc7f;
 }
 
 .btn:hover {
@@ -1571,5 +1571,128 @@ a {
     bottom: 16px;
     width: auto;
     max-height: 62vh;
+  }
+}
+
+/* ==========================================================================
+   Load curtain & hero entrance
+   The curtain is the same near-black as the page, so it reads as a held
+   moment rather than a separate screen. Both are gated behind classes set by
+   the inline script in index.html, so with JS off nothing is ever hidden.
+   ========================================================================== */
+
+.loader {
+  display: none;
+}
+
+html.intro-loader .loader {
+  /* Below the film grain (z 9990) so the texture stays continuous across the
+     lift, above everything else. */
+  position: fixed;
+  inset: 0;
+  z-index: 9000;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-6);
+  background: var(--bg);
+  transition: opacity 220ms ease-out;
+}
+
+/* Set by script.js once the page is ready. Pointer-events go first so the
+   fading curtain never eats a click on the CTA underneath. */
+html.intro-loader .loader.is-done {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.loader-mark {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-family: var(--font-heading);
+  font-size: var(--text-md);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+.loader-track {
+  position: relative;
+  width: 200px;
+  max-width: 60vw;
+  height: 1px;
+  background: var(--border-strong);
+  overflow: hidden;
+}
+
+.loader-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0;
+  background: var(--primary-blue);
+  box-shadow: 0 0 12px rgba(84, 155, 230, 0.8);
+  transition: width 240ms cubic-bezier(0.33, 1, 0.68, 1);
+}
+
+/* --- Hero entrance -------------------------------------------------------
+   Elements rest in their hidden state only while .intro-armed is on <html>.
+   script.js drops that class to play every beat at once, each offset by its
+   own --intro-delay. */
+
+[data-intro] {
+  transition:
+    opacity 380ms cubic-bezier(0.2, 0.7, 0.2, 1) var(--intro-delay, 0ms),
+    transform 380ms cubic-bezier(0.2, 0.7, 0.2, 1) var(--intro-delay, 0ms);
+}
+
+html.intro-armed [data-intro] {
+  opacity: 0;
+  transform: translateY(12px);
+}
+
+/* Transform needs a block-level box; these two are inline spans in the h1. */
+.hero h1 .line {
+  display: inline-block;
+}
+
+[data-intro="eyebrow"] {
+  --intro-delay: 60ms;
+}
+[data-intro="head1"] {
+  --intro-delay: 120ms;
+}
+[data-intro="head2"] {
+  --intro-delay: 180ms;
+}
+[data-intro="cta"] {
+  --intro-delay: 260ms;
+}
+[data-intro="blurb"] {
+  --intro-delay: 340ms;
+}
+[data-intro="wayfinding"] {
+  --intro-delay: 340ms;
+}
+
+/* This one is vertically centred with translateY(-50%), so the generic armed
+   transform above would clobber its position and make it slide ~104px instead
+   of the intended 12px. Compose the offset into its own transform. */
+html.intro-armed [data-intro="wayfinding"] {
+  transform: translateY(calc(-50% + 12px));
+}
+
+/* Reveal without motion for anyone who scrolled while the curtain was up. */
+html.intro-instant [data-intro] {
+  transition: none;
+}
+
+/* No motion preference: the inline script never arms the intro, but guard the
+   transitions too in case the preference changes after load. */
+@media (prefers-reduced-motion: reduce) {
+  .loader,
+  [data-intro] {
+    transition: none;
   }
 }

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,948 +1,1223 @@
-/* Reset and Base Styles */
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-}
+/* ==========================================================================
+   Wispr — design tokens
+   Edit these variables to customize the site.
+   ========================================================================== */
 
 :root {
-    /* Color palette from Wispr icon */
-    --primary-blue: rgb(84, 155, 230);
-    --deep-blue: rgb(33, 38, 162);
-    --light-blue: rgb(173, 225, 252);
-    --sky-blue: rgb(189, 247, 255);
-    --accent-blue: rgb(119, 201, 255);
-    --dark-bg: rgb(44, 45, 51);
-    --light-gray: rgb(214, 230, 243);
-    --white: rgb(255, 252, 253);
-    
-    /* Gradients */
-    --gradient-primary: linear-gradient(135deg, var(--deep-blue), var(--primary-blue));
-    --gradient-light: linear-gradient(135deg, var(--light-blue), var(--sky-blue));
-    --gradient-accent: linear-gradient(135deg, var(--primary-blue), var(--accent-blue));
+  /* Brand colors */
+  --primary-blue: rgb(84, 155, 230);
+  --deep-blue: rgb(33, 38, 162);
+  --light-blue: rgb(173, 225, 252);
+
+  /* Dark theme surfaces */
+  --bg: #0a0a0b;
+  --bg-raised: #101013;
+  --surface: rgba(255, 255, 255, 0.03);
+  --surface-strong: rgba(255, 255, 255, 0.06);
+  --border: rgba(255, 255, 255, 0.08);
+  --border-strong: rgba(255, 255, 255, 0.14);
+  --hairline: rgba(255, 255, 255, 0.05);
+
+  /* Text */
+  --text: #f4f5f7;
+  --text-secondary: #a0a3ab;
+  --text-faint: rgba(255, 255, 255, 0.35);
+
+  /* Typography */
+  --font-heading: 'Space Grotesk', 'Avenir Next', 'Helvetica Neue', Arial, sans-serif;
+  --font-body: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
+  --font-mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+
+  /* Type scale */
+  --text-xs: 0.8125rem;
+  --text-sm: 0.875rem;
+  --text-base: 0.9375rem;
+  --text-md: 1.125rem;
+  --text-lg: 1.375rem;
+  --text-h2: clamp(2rem, 4.4vw, 3.25rem);
+  /* Sized so "Your voice, your words." holds one line from 1200px up */
+  --text-hero: clamp(3.1rem, calc(9.5vw - 45px), 6.75rem);
+
+  /* Spacing */
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-12: 3rem;
+  --space-14: 3.5rem;
+  --section-pad: clamp(88px, 12vh, 140px);
+  --gutter: clamp(24px, 5vw, 72px);
+
+  /* Shape & motion */
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 20px;
+  --transition: 0.22s ease;
+  --header-height: 72px;
+}
+
+/* ==========================================================================
+   Reset & base
+   ========================================================================== */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 html {
-    scroll-behavior: smooth;
-    scroll-snap-type: y mandatory;
-    overflow-y: scroll;
+  scroll-behavior: smooth;
+  scroll-snap-type: y proximity;
+  overflow-x: hidden;
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-    line-height: 1.6;
-    color: #333;
-    overflow-x: hidden;
-    opacity: 0;
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--text);
+  background-color: var(--bg);
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
 }
 
-/* Section Snap Scrolling */
-.section {
-    min-height: 100vh;
-    scroll-snap-align: start;
-    scroll-snap-stop: always;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 4rem 2rem;
-    position: relative;
+/* Film-grain overlay — sits above everything, purely decorative */
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 9990;
+  pointer-events: none;
+  opacity: 0.05;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 180px 180px;
+}
+
+h1, h2, h3 {
+  font-family: var(--font-heading);
+  color: var(--text);
+  margin: 0;
+}
+
+p {
+  margin: 0;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: var(--primary-blue);
+  text-decoration: none;
+}
+
+::selection {
+  background: var(--primary-blue);
+  color: var(--bg);
+}
+
+:focus-visible {
+  outline: 2px solid var(--light-blue);
+  outline-offset: 3px;
+}
+
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: var(--space-4);
+  z-index: 10000;
+  padding: 12px 20px;
+  border-radius: var(--radius-sm);
+  background: var(--text);
+  color: var(--bg);
+  font-weight: 500;
+}
+
+.skip-link:focus {
+  top: var(--space-4);
 }
 
 .container {
-    max-width: 1200px;
-    width: 100%;
-    margin: 0 auto;
-    text-align: center;
+  max-width: 1160px;
+  margin-inline: auto;
 }
 
-/* Hero Section */
+/* ==========================================================================
+   Header
+   ========================================================================== */
+
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  transition: background var(--transition), border-color var(--transition);
+  border-bottom: 1px solid transparent;
+}
+
+.site-header.scrolled {
+  background: rgba(10, 10, 11, 0.78);
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+  border-bottom-color: var(--hairline);
+}
+
+.header-inner {
+  position: relative;
+  max-width: 1440px;
+  margin-inline: auto;
+  height: var(--header-height);
+  padding: 0 var(--gutter);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-6);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-heading);
+  font-size: var(--text-md);
+  font-weight: 600;
+  color: var(--text);
+}
+
+.primary-nav {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: var(--space-2);
+}
+
+.primary-nav a,
+.ghost-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 14px;
+  font-size: var(--text-sm);
+  letter-spacing: 0.02em;
+  color: var(--text-secondary);
+  border-radius: var(--radius-sm);
+  transition: color var(--transition);
+}
+
+.primary-nav a:hover,
+.ghost-link:hover {
+  color: var(--text);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+/* ==========================================================================
+   Buttons
+   ========================================================================== */
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 14px 26px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition),
+              transform var(--transition), box-shadow var(--transition);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+}
+
+.btn:active {
+  transform: translateY(0);
+}
+
+.btn-light {
+  background: #f5f6f8;
+  color: #0a0a0b;
+}
+
+.btn-light:hover {
+  background: #ffffff;
+  box-shadow: 0 8px 30px rgba(84, 155, 230, 0.25);
+}
+
+.btn-glass {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--border-strong);
+  color: var(--text);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+}
+
+.btn-glass:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.22);
+}
+
+.btn-sm {
+  padding: 10px 18px;
+  font-size: var(--text-sm);
+}
+
+.btn-block {
+  width: 100%;
+}
+
+.chip-stack {
+  display: inline-flex;
+}
+
+.chip {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.chip + .chip {
+  margin-left: -9px;
+}
+
+.chip-heart {
+  background: linear-gradient(135deg, var(--primary-blue), var(--deep-blue));
+  color: #ffffff;
+}
+
+/* ==========================================================================
+   Sections (shared)
+   ========================================================================== */
+
+.section {
+  position: relative;
+  padding: var(--section-pad) var(--gutter);
+  scroll-snap-align: start;
+  scroll-margin-top: var(--header-height);
+  border-top: 1px solid var(--hairline);
+}
+
+.section-eyebrow {
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--primary-blue);
+  margin-bottom: var(--space-4);
+}
+
+.section h2 {
+  font-size: var(--text-h2);
+  font-weight: 700;
+  line-height: 1.08;
+  letter-spacing: -0.02em;
+  margin-bottom: var(--space-4);
+}
+
+.section-subtitle {
+  color: var(--text-secondary);
+  max-width: 560px;
+}
+
+/* ==========================================================================
+   1. Hero
+   ========================================================================== */
+
 .hero {
-    background: var(--gradient-primary);
-    color: white;
-    position: relative;
-    overflow: hidden;
+  border-top: none;
+  min-height: 100vh;
+  padding-top: calc(var(--header-height) + 64px);
+  padding-bottom: 96px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
 }
 
-.hero::before {
-    content: '';
-    position: absolute;
-    top: -50%;
-    right: -50%;
-    width: 100%;
-    height: 100%;
-    background: radial-gradient(circle, rgba(189, 247, 255, 0.1) 0%, transparent 70%);
-    animation: float 20s ease-in-out infinite;
+@supports (min-height: 100svh) {
+  .hero {
+    min-height: 100svh;
+  }
 }
 
-@keyframes float {
-    0%, 100% { transform: translate(0, 0) rotate(0deg); }
-    50% { transform: translate(-20px, 20px) rotate(5deg); }
+/* Soft irregular glow behind the headline */
+.hero-glow {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
 }
 
-.logo {
-    width: 120px;
-    height: 120px;
-    margin-bottom: 2rem;
-    filter: drop-shadow(0 10px 30px rgba(0, 0, 0, 0.3));
-    animation: fadeInUp 0.8s ease-out;
+.glow-blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(90px);
+  will-change: transform;
+}
+
+.glow-blob-a {
+  width: clamp(420px, 48vw, 780px);
+  height: clamp(420px, 48vw, 780px);
+  left: 16%;
+  top: 4%;
+  background: radial-gradient(circle at 35% 35%,
+      rgba(84, 155, 230, 0.6),
+      rgba(84, 155, 230, 0.2) 45%,
+      transparent 70%);
+  animation: drift-a 26s ease-in-out infinite alternate;
+}
+
+.glow-blob-b {
+  width: clamp(380px, 42vw, 700px);
+  height: clamp(380px, 42vw, 700px);
+  left: 44%;
+  top: 28%;
+  background: radial-gradient(circle at 60% 40%,
+      rgba(33, 38, 162, 0.55),
+      rgba(33, 38, 162, 0.2) 50%,
+      transparent 72%);
+  animation: drift-b 32s ease-in-out infinite alternate;
+}
+
+.glow-blob-c {
+  width: clamp(200px, 20vw, 320px);
+  height: clamp(200px, 20vw, 320px);
+  left: 32%;
+  top: 24%;
+  background: radial-gradient(circle,
+      rgba(173, 225, 252, 0.3),
+      transparent 65%);
+  filter: blur(70px);
+  animation: drift-c 22s ease-in-out infinite alternate;
+}
+
+@keyframes drift-a {
+  from { transform: translate(0, 0) scale(1); }
+  to   { transform: translate(5%, 8%) scale(1.12); }
+}
+
+@keyframes drift-b {
+  from { transform: translate(0, 0) scale(1.08) rotate(0deg); }
+  to   { transform: translate(-6%, -5%) scale(1) rotate(8deg); }
+}
+
+@keyframes drift-c {
+  from { transform: translate(0, 0); }
+  to   { transform: translate(10%, 14%) scale(1.2); }
+}
+
+/* Hairline crosshair accents */
+.hero-crosshair {
+  position: absolute;
+  right: 13%;
+  bottom: 24%;
+  width: 300px;
+  height: 300px;
+  pointer-events: none;
+}
+
+.crosshair-h,
+.crosshair-v,
+.crosshair-diag {
+  position: absolute;
+  background: rgba(255, 255, 255, 0.13);
+}
+
+.crosshair-h {
+  top: 50%;
+  left: -35%;
+  width: 170%;
+  height: 1px;
+}
+
+.crosshair-v {
+  left: 50%;
+  top: -35%;
+  width: 1px;
+  height: 170%;
+}
+
+.crosshair-diag {
+  top: 50%;
+  left: 50%;
+  width: 480px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.11), transparent);
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+/* Decorative wayfinding columns, left mid-page */
+.hero-wayfinding {
+  position: absolute;
+  left: var(--gutter);
+  top: 48%;
+  transform: translateY(-50%);
+  display: flex;
+  gap: var(--space-12);
+}
+
+.hero-wayfinding ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.hero-wayfinding a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  font-size: var(--text-xs);
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  transition: color var(--transition);
+}
+
+.hero-wayfinding a:hover {
+  color: var(--text);
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  margin-left: min(21vw, 300px);
+  max-width: 1160px;
+}
+
+.hero-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
 }
 
 .hero h1 {
-    font-size: 5rem;
-    font-weight: 700;
-    margin-bottom: 1rem;
-    letter-spacing: -0.02em;
-    animation: fadeInUp 0.8s ease-out 0.2s both;
+  font-size: var(--text-hero);
+  font-weight: 700;
+  line-height: 1.02;
+  letter-spacing: -0.035em;
+  margin: var(--space-6) 0 var(--space-12);
 }
 
-.tagline {
-    font-size: 2rem;
-    font-weight: 300;
-    margin-bottom: 1rem;
-    opacity: 0.95;
-    animation: fadeInUp 0.8s ease-out 0.4s both;
+.hero-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
 }
 
-.subtitle {
-    font-size: 1.25rem;
-    opacity: 0.85;
-    max-width: 600px;
-    margin: 0 auto 3rem;
-    animation: fadeInUp 0.8s ease-out 0.6s both;
+.hero-blurb {
+  position: relative;
+  z-index: 1;
+  margin-left: min(21vw, 300px);
+  margin-top: clamp(48px, 9vh, 110px);
+  max-width: 400px;
+  font-size: var(--text-base);
+  line-height: 1.65;
+  color: var(--text-secondary);
 }
 
-.hero-cta-group {
-    display: flex;
-    gap: 1.5rem;
-    justify-content: center;
-    align-items: center;
-    flex-wrap: wrap;
-    animation: fadeInUp 0.8s ease-out 0.8s both;
+/* Tilted preview cropped by the viewport edge */
+.hero-preview {
+  position: absolute;
+  right: -72px;
+  bottom: -44px;
+  width: min(420px, 34vw);
+  margin: 0;
+  transform: rotate(-8deg);
+  z-index: 1;
 }
 
-.cta-button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 1rem 3rem;
-    text-decoration: none;
-    border-radius: 50px;
-    font-size: 1.125rem;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+.hero-preview img {
+  width: 100%;
+  height: auto;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 40px 90px rgba(0, 0, 0, 0.65);
 }
 
-.cta-button svg {
-    flex-shrink: 0;
-}
-
-.cta-button.primary {
-    background: white;
-    color: var(--deep-blue);
-}
-
-.cta-button.primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.3);
-}
-
-.cta-button.secondary {
-    background: rgba(255, 255, 255, 0.15);
-    color: white;
-    backdrop-filter: blur(10px);
-    border: 2px solid rgba(255, 255, 255, 0.3);
-}
-
-.cta-button.secondary:hover {
-    background: rgba(255, 255, 255, 0.25);
-    transform: translateY(-2px);
-    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.3);
-}
-
-.scroll-indicator {
-    position: absolute;
-    bottom: 2rem;
-    left: 50%;
-    transform: translateX(-50%);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-    color: white;
-    opacity: 0.7;
-    animation: bounce 2s ease-in-out infinite;
-}
-
-@keyframes bounce {
-    0%, 100% { transform: translateX(-50%) translateY(0); }
-    50% { transform: translateX(-50%) translateY(10px); }
-}
-
-@keyframes fadeInUp {
-    from {
-        opacity: 0;
-        transform: translateY(30px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-/* Download/Install Section */
-.download-section {
-    background: linear-gradient(135deg, var(--deep-blue), var(--primary-blue));
-    color: white;
-}
+/* ==========================================================================
+   2. Download / Install
+   ========================================================================== */
 
 .download-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
-    gap: 2rem;
-    max-width: 1000px;
-    margin: 0 auto;
-    align-items: start;
+  display: grid;
+  grid-template-columns: 1.15fr 0.85fr;
+  gap: var(--space-6);
+  margin-top: var(--space-14);
 }
 
-.download-card {
-    background: rgba(255, 255, 255, 0.1);
-    backdrop-filter: blur(20px);
-    border: 2px solid rgba(255, 255, 255, 0.2);
-    border-radius: 24px;
-    padding: 3rem 2.5rem;
-    text-align: center;
-    transition: all 0.3s ease;
-    height: 100%;
-    display: flex;
-    flex-direction: column;
+.panel {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02));
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 36px;
 }
 
-.card-bottom {
-    margin-top: auto;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+.panel h3 {
+  font-size: var(--text-lg);
+  font-weight: 600;
 }
 
-.download-card:hover {
-    transform: translateY(-5px);
-    background: rgba(255, 255, 255, 0.15);
-    border-color: rgba(255, 255, 255, 0.3);
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+.panel-subtitle {
+  color: var(--text-secondary);
+  font-size: var(--text-base);
+  margin: 6px 0 28px;
 }
 
-.donate-card {
-    background: linear-gradient(135deg, rgba(255, 107, 107, 0.2), rgba(255, 159, 64, 0.2));
-    border-color: rgba(255, 255, 255, 0.3);
-}
-
-.donate-card:hover {
-    background: linear-gradient(135deg, rgba(255, 107, 107, 0.3), rgba(255, 159, 64, 0.3));
-}
-
-.card-icon {
-    width: 80px;
-    height: 80px;
-    margin: 0 auto 1.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(255, 255, 255, 0.15);
-    border-radius: 20px;
-    color: white;
-}
-
-.heart-icon {
-    background: linear-gradient(135deg, rgba(255, 107, 107, 0.3), rgba(255, 159, 64, 0.3));
-}
-
-.download-card h2 {
-    font-size: 2rem;
-    margin-bottom: 0.5rem;
-    color: white;
-}
-
-.card-subtitle {
-    font-size: 1.125rem;
-    opacity: 0.9;
-    margin-bottom: 2rem;
-}
-
-.install-option {
-    margin: 1.5rem 0 0;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+.version-info {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  text-align: center;
+  margin-top: var(--space-3);
 }
 
 .install-divider {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    margin: 3rem 0 0.5rem;
-    opacity: 0.8;
-    font-size: 0.9375rem;
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin: 28px 0;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .install-divider::before,
 .install-divider::after {
-    content: '';
-    flex: 1;
-    height: 1px;
-    background: rgba(255, 255, 255, 0.25);
-}
-
-.install-divider span {
-    white-space: nowrap;
-}
-
-.install-steps {
-    margin: 1.5rem 0 0;
+  content: "";
+  height: 1px;
+  flex: 1;
+  background: var(--border);
 }
 
 .code-block {
-    background: rgba(0, 0, 0, 0.3);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 12px;
-    padding: 1rem 1.5rem;
-    margin-bottom: 1rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: 8px 8px 8px 18px;
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.code-block + .code-block {
+  margin-top: var(--space-3);
 }
 
 .code-block code {
-    font-family: 'SF Mono', 'Monaco', 'Courier New', monospace;
-    font-size: 1rem;
-    color: var(--sky-blue);
-    flex: 1;
-    text-align: left;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--light-blue);
+  overflow-x: auto;
 }
 
 .copy-btn {
-    background: rgba(255, 255, 255, 0.2);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    color: white;
-    padding: 0.5rem 1rem;
-    border-radius: 8px;
-    cursor: pointer;
-    font-size: 0.875rem;
-    font-weight: 600;
-    transition: all 0.2s ease;
+  flex-shrink: 0;
+  min-height: 44px;
+  padding: 10px 16px;
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
 }
 
 .copy-btn:hover {
-    background: rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.12);
 }
 
-.copy-btn:active {
-    transform: scale(0.95);
+.copy-btn.copied {
+  color: var(--light-blue);
+  border-color: rgba(84, 155, 230, 0.5);
 }
 
-.download-button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.75rem;
-    padding: 1rem 2.5rem;
-    background: white;
-    color: var(--deep-blue);
-    text-decoration: none;
-    border-radius: 50px;
-    font-size: 1.125rem;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
-    margin: 0 auto;
-    width: fit-content;
+.benefit-list {
+  list-style: none;
+  margin: 0 0 28px;
+  padding: 0;
+  display: grid;
+  gap: 14px;
 }
 
-.download-button svg {
-    flex-shrink: 0;
+.benefit-list li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: var(--text-base);
+  color: var(--text-secondary);
 }
 
-.download-button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.3);
-}
-
-.version-info {
-    font-size: 0.875rem;
-    opacity: 0.7;
-    margin-top: 0.75rem;
-}
-
-.donate-benefits {
-    text-align: left;
-    margin: 2rem 0;
-}
-
-.benefit {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-    font-size: 1rem;
-}
-
-.benefit svg {
-    flex-shrink: 0;
-    color: var(--sky-blue);
-}
-
-.donate-button-large {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.75rem;
-    padding: 1.25rem 3rem;
-    background: linear-gradient(135deg, #ff6b6b, #ff9f40);
-    color: white;
-    text-decoration: none;
-    border-radius: 50px;
-    font-size: 1.25rem;
-    font-weight: 700;
-    transition: all 0.3s ease;
-    box-shadow: 0 15px 40px rgba(255, 107, 107, 0.4);
-    margin: 0 auto;
-    animation: pulse 2s ease-in-out infinite;
-    width: fit-content;
-}
-
-.donate-button-large svg {
-    flex-shrink: 0;
-}
-
-@keyframes pulse {
-    0%, 100% { transform: scale(1); }
-    50% { transform: scale(1.05); }
-}
-
-.donate-button-large:hover {
-    transform: translateY(-3px) scale(1.05);
-    box-shadow: 0 20px 50px rgba(255, 107, 107, 0.5);
-    animation: none;
+.benefit-list svg {
+  flex-shrink: 0;
+  color: var(--primary-blue);
 }
 
 .donate-note {
-    font-size: 0.875rem;
-    opacity: 0.8;
-    margin-top: 1rem;
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  text-align: center;
+  margin-top: var(--space-3);
 }
 
-/* Features Section */
-.features {
-    background: linear-gradient(180deg, #f8f9fa 0%, white 100%);
-}
-
-.features h2 {
-    font-size: 3rem;
-    margin-bottom: 4rem;
-    color: var(--deep-blue);
-}
+/* ==========================================================================
+   3. Features
+   ========================================================================== */
 
 .feature-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 2rem;
-    margin-top: 3rem;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-6);
+  margin-top: var(--space-14);
 }
 
 .feature-card {
-    background: white;
-    padding: 2.5rem 2rem;
-    border-radius: 20px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
-    transition: all 0.3s ease;
+  padding: 32px 28px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease;
 }
 
 .feature-card:hover {
-    transform: translateY(-10px);
-    box-shadow: 0 20px 50px rgba(84, 155, 230, 0.15);
+  transform: translateY(-4px);
+  border-color: rgba(84, 155, 230, 0.35);
+  background: var(--surface-strong);
 }
 
 .feature-icon {
-    font-size: 3rem;
-    margin-bottom: 1rem;
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 20px;
+  border-radius: var(--radius-md);
+  color: var(--light-blue);
+  background: rgba(84, 155, 230, 0.12);
+  border: 1px solid rgba(84, 155, 230, 0.25);
 }
 
 .feature-card h3 {
-    font-size: 1.5rem;
-    margin-bottom: 1rem;
-    color: var(--deep-blue);
+  font-size: var(--text-md);
+  font-weight: 600;
+  margin-bottom: 10px;
 }
 
 .feature-card p {
-    color: #666;
-    line-height: 1.7;
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-secondary);
 }
 
-/* How It Works Section */
-.how-it-works {
-    background: var(--gradient-light);
-}
-
-.how-it-works h2 {
-    font-size: 3rem;
-    margin-bottom: 4rem;
-    color: var(--deep-blue);
-}
+/* ==========================================================================
+   4. How It Works
+   ========================================================================== */
 
 .steps {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 3rem;
-    margin-top: 3rem;
+  list-style: none;
+  margin: var(--space-14) 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-8);
 }
 
 .step {
-    position: relative;
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--border-strong);
 }
 
 .step-number {
-    width: 80px;
-    height: 80px;
-    background: var(--gradient-primary);
-    color: white;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 2.5rem;
-    font-weight: 700;
-    margin: 0 auto 1.5rem;
-    box-shadow: 0 10px 30px rgba(84, 155, 230, 0.3);
+  font-family: var(--font-heading);
+  font-size: 2.75rem;
+  font-weight: 700;
+  color: var(--primary-blue);
+  line-height: 1;
 }
 
 .step h3 {
-    font-size: 1.75rem;
-    margin-bottom: 1rem;
-    color: var(--deep-blue);
+  font-size: var(--text-md);
+  font-weight: 600;
+  margin: var(--space-4) 0 10px;
 }
 
 .step p {
-    color: #555;
-    font-size: 1.125rem;
-    line-height: 1.7;
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-secondary);
 }
 
-/* Onboarding Section */
-.onboarding {
-    background: white;
+/* ==========================================================================
+   5. Onboarding carousel
+   ========================================================================== */
+
+.carousel {
+  max-width: 860px;
+  margin: var(--space-14) auto 0;
 }
 
-.onboarding h2 {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-    color: var(--deep-blue);
+.carousel-viewport {
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  border-radius: var(--radius-lg);
 }
 
-.onboarding-carousel {
-    margin-top: 3rem;
-    position: relative;
+.carousel-viewport::-webkit-scrollbar {
+  display: none;
 }
 
-.carousel-container {
-    overflow: hidden;
-    border-radius: 20px;
-    background: #f8f9fa;
-    padding: 2rem 0;
+.carousel-viewport:focus-visible {
+  outline: 2px solid var(--light-blue);
+  outline-offset: 4px;
 }
 
 .carousel-track {
-    display: flex;
-    gap: 2rem;
-    transition: transform 0.5s ease;
-    padding: 0 2rem;
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
-.onboarding-slide {
-    flex: 0 0 calc(100% - 4rem);
-    max-width: 800px;
-    margin: 0 auto;
-    text-align: center;
+.carousel-slide {
+  flex: 0 0 100%;
+  scroll-snap-align: start;
 }
 
-.onboarding-slide img {
-    width: 100%;
-    height: auto;
-    border-radius: 16px;
-    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
-    transition: transform 0.3s ease;
+.carousel-slide figure {
+  margin: 0;
+  height: 100%;
+  padding: 28px 28px 24px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
 }
 
-.onboarding-slide img:hover {
-    transform: scale(1.02);
+.carousel-slide img {
+  width: 100%;
+  max-width: 560px;
+  height: auto;
+  border-radius: var(--radius-md);
 }
 
-.slide-caption {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 1rem;
-    margin-top: 1.5rem;
+.carousel-slide figcaption {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-base);
+  color: var(--text-secondary);
 }
 
 .slide-number {
-    width: 40px;
-    height: 40px;
-    background: var(--gradient-primary);
-    color: white;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: 700;
-    font-size: 1.125rem;
-    flex-shrink: 0;
-}
-
-.slide-caption p {
-    font-size: 1.125rem;
-    color: var(--deep-blue);
-    font-weight: 500;
-    margin: 0;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-family: var(--font-heading);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--light-blue);
+  background: rgba(84, 155, 230, 0.15);
+  border: 1px solid rgba(84, 155, 230, 0.3);
 }
 
 .carousel-controls {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 2rem;
-    margin-top: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-6);
+  margin-top: var(--space-6);
 }
 
 .carousel-btn {
-    width: 48px;
-    height: 48px;
-    border-radius: 50%;
-    background: white;
-    border: 2px solid var(--primary-blue);
-    color: var(--primary-blue);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 12px rgba(84, 155, 230, 0.2);
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border-strong);
+  color: var(--text);
+  cursor: pointer;
+  transition: background var(--transition), opacity var(--transition);
 }
 
 .carousel-btn:hover:not(:disabled) {
-    background: var(--primary-blue);
-    color: white;
-    transform: scale(1.1);
-    box-shadow: 0 6px 20px rgba(84, 155, 230, 0.3);
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .carousel-btn:disabled {
-    opacity: 0.3;
-    cursor: not-allowed;
+  opacity: 0.35;
+  cursor: default;
 }
 
 .carousel-dots {
-    display: flex;
-    gap: 0.75rem;
+  display: flex;
+  gap: 4px;
 }
 
 .carousel-dot {
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    background: #ddd;
-    border: none;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    padding: 0;
+  position: relative;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
 }
 
-.carousel-dot:hover {
-    background: var(--light-blue);
-    transform: scale(1.2);
+.carousel-dot::after {
+  content: "";
+  position: absolute;
+  inset: 9px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.25);
+  transition: background var(--transition), inset var(--transition);
 }
 
-.carousel-dot.active {
-    background: var(--primary-blue);
-    width: 32px;
-    border-radius: 6px;
+.carousel-dot.active::after {
+  inset: 7px;
+  background: var(--primary-blue);
 }
 
-/* Screenshots Section */
-.screenshots {
-    background: white;
-}
-
-.screenshots h2 {
-    font-size: 3rem;
-    margin-bottom: 1rem;
-    color: var(--deep-blue);
-}
-
-.section-subtitle {
-    font-size: 1.25rem;
-    color: #666;
-    margin-bottom: 4rem;
-}
+/* ==========================================================================
+   6. Screenshots
+   ========================================================================== */
 
 .screenshot-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 2rem;
-    margin-top: 3rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-6);
+  margin-top: var(--space-14);
 }
 
 .screenshot-item {
-    background: #f8f9fa;
-    border-radius: 20px;
-    overflow: hidden;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
-    transition: all 0.3s ease;
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 28px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  transition: transform 0.25s ease, border-color 0.25s ease;
 }
 
 .screenshot-item:hover {
-    transform: scale(1.05);
-    box-shadow: 0 20px 50px rgba(84, 155, 230, 0.2);
+  transform: translateY(-4px);
+  border-color: rgba(84, 155, 230, 0.35);
+}
+
+.shot-menu {
+  grid-column: 1 / -1;
 }
 
 .screenshot-item img {
-    width: 100%;
-    height: auto;
-    display: block;
-    flex-grow: 1;
-    object-fit: contain;
-    padding: 1rem;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+  border-radius: 10px;
 }
 
-.screenshot-item p {
-    padding: 1.5rem;
-    font-size: 1.125rem;
-    color: var(--deep-blue);
-    font-weight: 500;
-    margin: 0;
-    margin-top: auto;
+.shot-menu img {
+  max-width: 640px;
+  margin-inline: auto;
 }
 
-/* Use Cases Section */
-.use-cases {
-    background: linear-gradient(180deg, #f8f9fa 0%, white 100%);
+.screenshot-item figcaption {
+  margin-top: auto;
+  padding-top: var(--space-4);
+  text-align: center;
+  font-size: var(--text-base);
+  color: var(--text-secondary);
 }
 
-.use-cases h2 {
-    font-size: 3rem;
-    margin-bottom: 4rem;
-    color: var(--deep-blue);
-}
+/* ==========================================================================
+   7. Use Cases
+   ========================================================================== */
 
 .use-case-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 2rem;
-    margin-top: 3rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-6);
+  margin-top: var(--space-14);
 }
 
 .use-case {
-    background: white;
-    padding: 2.5rem 2rem;
-    border-radius: 20px;
-    border-left: 4px solid var(--primary-blue);
-    box-shadow: 0 5px 20px rgba(0, 0, 0, 0.08);
-    transition: all 0.3s ease;
+  padding: var(--space-6) var(--space-2) var(--space-2);
+  border-top: 1px solid var(--border-strong);
+  transition: border-color 0.25s ease;
 }
 
 .use-case:hover {
-    border-left-width: 8px;
-    transform: translateX(5px);
+  border-top-color: rgba(84, 155, 230, 0.5);
 }
 
 .use-case h3 {
-    font-size: 1.5rem;
-    margin-bottom: 1rem;
-    color: var(--deep-blue);
+  font-size: var(--text-lg);
+  font-weight: 600;
+  margin-bottom: 10px;
 }
 
 .use-case p {
-    color: #666;
-    line-height: 1.7;
+  font-size: var(--text-base);
+  line-height: 1.6;
+  color: var(--text-secondary);
 }
 
-/* Support Section */
+/* ==========================================================================
+   8. Support
+   ========================================================================== */
+
 .support {
-    background: var(--gradient-primary);
-    color: white;
+  text-align: center;
+  overflow: hidden;
 }
 
-.support h2 {
-    font-size: 3rem;
-    margin-bottom: 2rem;
+.support .section-subtitle,
+.support-text {
+  margin-inline: auto;
 }
 
 .support-text {
-    font-size: 1.25rem;
-    margin-bottom: 3rem;
-    opacity: 0.9;
-    max-width: 600px;
-    margin-left: auto;
-    margin-right: auto;
+  max-width: 480px;
+  color: var(--text-secondary);
+  margin-bottom: var(--space-8);
 }
 
-.donate-button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.75rem;
-    padding: 1.25rem 3.5rem;
-    background: white;
-    color: var(--deep-blue);
-    text-decoration: none;
-    border-radius: 50px;
-    font-size: 1.25rem;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+.support-glow {
+  position: absolute;
+  left: 50%;
+  top: 55%;
+  transform: translate(-50%, -50%);
+  width: min(720px, 90vw);
+  height: min(450px, 56vw);
+  background: radial-gradient(ellipse at center,
+      rgba(84, 155, 230, 0.28),
+      rgba(33, 38, 162, 0.15) 45%,
+      transparent 70%);
+  filter: blur(60px);
+  pointer-events: none;
 }
 
-.donate-button svg {
-    flex-shrink: 0;
+.support .container {
+  position: relative;
 }
 
-.donate-button:hover {
-    transform: translateY(-3px) scale(1.05);
-    box-shadow: 0 15px 40px rgba(0, 0, 0, 0.3);
-}
+/* ==========================================================================
+   9. Footer
+   ========================================================================== */
 
-.support-note {
-    margin-top: 2rem;
-    opacity: 0.8;
-    font-size: 1rem;
-}
-
-/* Footer */
 .footer {
-    background: var(--dark-bg);
-    color: white;
-    padding: 3rem 2rem;
-    text-align: center;
+  border-top: 1px solid var(--hairline);
+  padding: 48px var(--gutter);
 }
 
-.footer p {
-    margin-bottom: 1rem;
-    opacity: 0.8;
+.footer-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-6);
+  flex-wrap: wrap;
+}
+
+.brand-footer {
+  font-size: 1rem;
 }
 
 .footer-links {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 1rem;
+  display: flex;
+  gap: var(--space-2);
 }
 
 .footer-links a {
-    color: var(--light-blue);
-    text-decoration: none;
-    transition: color 0.3s ease;
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  padding: 0 12px;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  transition: color var(--transition);
 }
 
 .footer-links a:hover {
-    color: var(--sky-blue);
+  color: var(--text);
 }
 
-.footer-links span {
-    opacity: 0.5;
+.footer-copy {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
 }
 
-/* Responsive Design */
-@media (max-width: 768px) {
-    .hero h1 {
-        font-size: 3rem;
-    }
-    
-    .tagline {
-        font-size: 1.5rem;
-    }
-    
-    .subtitle {
-        font-size: 1rem;
-    }
-    
-    .hero-cta-group {
-        flex-direction: column;
-        gap: 1rem;
-    }
-    
-    .cta-button {
-        width: 100%;
-        max-width: 300px;
-        justify-content: center;
-    }
-    
-    .download-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    .download-card {
-        padding: 2rem 1.5rem;
-    }
-    
-    .code-block {
-        flex-direction: column;
-        align-items: stretch;
-    }
-    
-    .code-block code {
-        text-align: center;
-        font-size: 0.875rem;
-    }
-    
-    .carousel-track {
-        padding: 0 1rem;
-    }
-    
-    .onboarding-slide {
-        flex: 0 0 calc(100% - 2rem);
-    }
-    
-    .carousel-controls {
-        gap: 1rem;
-    }
-    
-    .carousel-btn {
-        width: 40px;
-        height: 40px;
-    }
-    
-    .slide-caption {
-        flex-direction: column;
-        gap: 0.5rem;
-    }
-    
-    .features h2,
-    .how-it-works h2,
-    .screenshots h2,
-    .use-cases h2,
-    .support h2,
-    .onboarding h2 {
-        font-size: 2rem;
-    }
-    
-    .feature-grid,
-    .steps,
-    .screenshot-grid,
-    .use-case-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    .section {
-        padding: 3rem 1.5rem;
-    }
+/* ==========================================================================
+   Scroll reveal (activated by script.js; content stays visible without JS)
+   ========================================================================== */
+
+.js .reveal {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
 }
 
-/* Smooth scroll for browsers that don't support scroll-snap */
-@supports not (scroll-snap-type: y mandatory) {
-    html {
-        scroll-behavior: smooth;
-    }
+.js .reveal.is-visible {
+  opacity: 1;
+  transform: none;
+}
+
+/* ==========================================================================
+   Responsive
+   ========================================================================== */
+
+@media (max-width: 1199px) {
+  .hero-wayfinding {
+    display: none;
+  }
+
+  .hero-content,
+  .hero-blurb {
+    margin-left: 0;
+  }
+}
+
+@media (max-width: 1023px) {
+  .feature-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 899px) {
+  .primary-nav {
+    display: none;
+  }
+
+  .hero-crosshair,
+  .hero-preview {
+    display: none;
+  }
+
+  .download-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .steps {
+    grid-template-columns: 1fr;
+    gap: var(--space-6);
+  }
+}
+
+@media (max-width: 767px) {
+  .screenshot-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .screenshot-item {
+    padding: 20px;
+  }
+
+  .carousel-slide figure {
+    padding: 18px 18px 16px;
+  }
+}
+
+@media (max-width: 639px) {
+  .feature-grid,
+  .use-case-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ghost-link {
+    display: none;
+  }
+
+  .panel {
+    padding: 24px;
+  }
+
+  .hero-cta .btn {
+    flex: 1 1 auto;
+  }
+}
+
+/* ==========================================================================
+   Reduced motion
+   ========================================================================== */
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .js .reveal {
+    opacity: 1;
+    transform: none;
+  }
+
+  .glow-blob {
+    animation: none;
+  }
 }

--- a/website/styles.css
+++ b/website/styles.css
@@ -24,9 +24,13 @@
   --text-faint: rgba(255, 255, 255, 0.35);
 
   /* Typography */
-  --font-heading: 'Space Grotesk', 'Avenir Next', 'Helvetica Neue', Arial, sans-serif;
-  --font-body: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
-  --font-mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
+  --font-heading:
+    "Space Grotesk", "Avenir Next", "Helvetica Neue", Arial, sans-serif;
+  --font-body:
+    "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial,
+    sans-serif;
+  --font-mono:
+    ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
 
   /* Type scale */
   --text-xs: 0.8125rem;
@@ -97,7 +101,9 @@ body::after {
   background-size: 180px 180px;
 }
 
-h1, h2, h3 {
+h1,
+h2,
+h3 {
   font-family: var(--font-heading);
   color: var(--text);
   margin: 0;
@@ -174,7 +180,9 @@ a {
   left: 0;
   right: 0;
   z-index: 100;
-  transition: background var(--transition), border-color var(--transition);
+  transition:
+    background var(--transition),
+    border-color var(--transition);
   border-bottom: 1px solid transparent;
 }
 
@@ -248,15 +256,28 @@ a {
   align-items: center;
   justify-content: center;
   gap: 10px;
-  padding: 14px 26px;
+  padding: 10px 14px;
   border: 1px solid transparent;
   border-radius: 10px;
   font-family: var(--font-body);
   font-size: var(--text-base);
   font-weight: 500;
   cursor: pointer;
-  transition: background var(--transition), border-color var(--transition),
-              transform var(--transition), box-shadow var(--transition);
+  transition:
+    background var(--transition),
+    border-color var(--transition),
+    transform var(--transition),
+    box-shadow var(--transition);
+}
+
+.instantly {
+  font-style: italic;
+  /* color: #f5f6f816; */
+  color: #f5f6f8;
+
+  text-shadow: 4px 0px 0px rgb(0, 122, 252);
+
+  /* -webkit-text-stroke: 1px #f5f6f8a2; Thickness and color of the border */
 }
 
 .btn:hover {
@@ -291,7 +312,7 @@ a {
 }
 
 .btn-sm {
-  padding: 10px 18px;
+  padding: 4px 18px;
   font-size: var(--text-sm);
 }
 
@@ -407,16 +428,20 @@ a {
   z-index: 0;
   pointer-events: none;
   background:
-    linear-gradient(to right,
+    linear-gradient(
+      to right,
       rgba(10, 10, 11, 0.94) 0%,
       rgba(10, 10, 11, 0.78) 34%,
       rgba(10, 10, 11, 0.34) 64%,
-      rgba(10, 10, 11, 0) 88%),
-    linear-gradient(to bottom,
+      rgba(10, 10, 11, 0) 88%
+    ),
+    linear-gradient(
+      to bottom,
       rgba(10, 10, 11, 0.88) 0%,
       rgba(10, 10, 11, 0) 24%,
       rgba(10, 10, 11, 0) 58%,
-      rgba(10, 10, 11, 0.94) 100%);
+      rgba(10, 10, 11, 0.94) 100%
+    );
 }
 
 .waves-active .hero-scrim {
@@ -448,10 +473,12 @@ a {
   height: clamp(420px, 48vw, 780px);
   left: 16%;
   top: 4%;
-  background: radial-gradient(circle at 35% 35%,
-      rgba(84, 155, 230, 0.6),
-      rgba(84, 155, 230, 0.2) 45%,
-      transparent 70%);
+  background: radial-gradient(
+    circle at 35% 35%,
+    rgba(84, 155, 230, 0.6),
+    rgba(84, 155, 230, 0.2) 45%,
+    transparent 70%
+  );
   animation: drift-a 26s ease-in-out infinite alternate;
 }
 
@@ -460,10 +487,12 @@ a {
   height: clamp(380px, 42vw, 700px);
   left: 44%;
   top: 28%;
-  background: radial-gradient(circle at 60% 40%,
-      rgba(33, 38, 162, 0.55),
-      rgba(33, 38, 162, 0.2) 50%,
-      transparent 72%);
+  background: radial-gradient(
+    circle at 60% 40%,
+    rgba(33, 38, 162, 0.55),
+    rgba(33, 38, 162, 0.2) 50%,
+    transparent 72%
+  );
   animation: drift-b 32s ease-in-out infinite alternate;
 }
 
@@ -472,26 +501,40 @@ a {
   height: clamp(200px, 20vw, 320px);
   left: 32%;
   top: 24%;
-  background: radial-gradient(circle,
-      rgba(173, 225, 252, 0.3),
-      transparent 65%);
+  background: radial-gradient(
+    circle,
+    rgba(173, 225, 252, 0.3),
+    transparent 65%
+  );
   filter: blur(70px);
   animation: drift-c 22s ease-in-out infinite alternate;
 }
 
 @keyframes drift-a {
-  from { transform: translate(0, 0) scale(1); }
-  to   { transform: translate(5%, 8%) scale(1.12); }
+  from {
+    transform: translate(0, 0) scale(1);
+  }
+  to {
+    transform: translate(5%, 8%) scale(1.12);
+  }
 }
 
 @keyframes drift-b {
-  from { transform: translate(0, 0) scale(1.08) rotate(0deg); }
-  to   { transform: translate(-6%, -5%) scale(1) rotate(8deg); }
+  from {
+    transform: translate(0, 0) scale(1.08) rotate(0deg);
+  }
+  to {
+    transform: translate(-6%, -5%) scale(1) rotate(8deg);
+  }
 }
 
 @keyframes drift-c {
-  from { transform: translate(0, 0); }
-  to   { transform: translate(10%, 14%) scale(1.2); }
+  from {
+    transform: translate(0, 0);
+  }
+  to {
+    transform: translate(10%, 14%) scale(1.2);
+  }
 }
 
 /* Hairline crosshair accents */
@@ -530,7 +573,12 @@ a {
   left: 50%;
   width: 480px;
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.11), transparent);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.11),
+    transparent
+  );
   transform: translate(-50%, -50%) rotate(-45deg);
 }
 
@@ -640,7 +688,11 @@ a {
 }
 
 .panel {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.02));
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.05),
+    rgba(255, 255, 255, 0.02)
+  );
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: 36px;
@@ -717,7 +769,10 @@ a {
   font-size: var(--text-xs);
   font-weight: 500;
   cursor: pointer;
-  transition: background var(--transition), border-color var(--transition), color var(--transition);
+  transition:
+    background var(--transition),
+    border-color var(--transition),
+    color var(--transition);
 }
 
 .copy-btn:hover {
@@ -773,7 +828,10 @@ a {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 18px;
-  transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+  transition:
+    transform 0.25s ease,
+    border-color 0.25s ease,
+    background 0.25s ease;
 }
 
 .feature-card:hover {
@@ -945,7 +1003,9 @@ a {
   border: 1px solid var(--border-strong);
   color: var(--text);
   cursor: pointer;
-  transition: background var(--transition), opacity var(--transition);
+  transition:
+    background var(--transition),
+    opacity var(--transition);
 }
 
 .carousel-btn:hover:not(:disabled) {
@@ -978,7 +1038,9 @@ a {
   inset: 9px;
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.25);
-  transition: background var(--transition), inset var(--transition);
+  transition:
+    background var(--transition),
+    inset var(--transition);
 }
 
 .carousel-dot.active::after {
@@ -1005,7 +1067,9 @@ a {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  transition: transform 0.25s ease, border-color 0.25s ease;
+  transition:
+    transform 0.25s ease,
+    border-color 0.25s ease;
 }
 
 .screenshot-item:hover {
@@ -1099,10 +1163,12 @@ a {
   transform: translate(-50%, -50%);
   width: min(720px, 90vw);
   height: min(450px, 56vw);
-  background: radial-gradient(ellipse at center,
-      rgba(84, 155, 230, 0.28),
-      rgba(33, 38, 162, 0.15) 45%,
-      transparent 70%);
+  background: radial-gradient(
+    ellipse at center,
+    rgba(84, 155, 230, 0.28),
+    rgba(33, 38, 162, 0.15) 45%,
+    transparent 70%
+  );
   filter: blur(60px);
   pointer-events: none;
 }
@@ -1163,7 +1229,9 @@ a {
 .js .reveal {
   opacity: 0;
   transform: translateY(24px);
-  transition: opacity 0.6s ease, transform 0.6s ease;
+  transition:
+    opacity 0.6s ease,
+    transform 0.6s ease;
 }
 
 .js .reveal.is-visible {
@@ -1182,12 +1250,13 @@ a {
 
   /* Copy is full-width from here down, so the scrim can no longer lean left */
   .hero-scrim {
-    background:
-      linear-gradient(to bottom,
-        rgba(10, 10, 11, 0.9) 0%,
-        rgba(10, 10, 11, 0.62) 30%,
-        rgba(10, 10, 11, 0.62) 62%,
-        rgba(10, 10, 11, 0.95) 100%);
+    background: linear-gradient(
+      to bottom,
+      rgba(10, 10, 11, 0.9) 0%,
+      rgba(10, 10, 11, 0.62) 30%,
+      rgba(10, 10, 11, 0.62) 62%,
+      rgba(10, 10, 11, 0.95) 100%
+    );
   }
 
   .hero-content,
@@ -1338,7 +1407,9 @@ a {
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: color var(--transition), background var(--transition);
+  transition:
+    color var(--transition),
+    background var(--transition);
 }
 
 .waves-panel-close:hover {
@@ -1459,7 +1530,9 @@ a {
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background var(--transition), transform var(--transition);
+  transition:
+    background var(--transition),
+    transform var(--transition);
 }
 
 .waves-btn:hover {

--- a/website/styles.css
+++ b/website/styles.css
@@ -1515,6 +1515,7 @@ a {
 
 .waves-panel-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   padding: 12px 14px;
   border-top: 1px solid var(--border);
@@ -1543,7 +1544,9 @@ a {
   transform: scale(0.98);
 }
 
+/* Takes its own row so "Replay intro" and "Reset" can share the one below */
 .waves-btn-primary {
+  flex-basis: 100%;
   color: #08131f;
   background: var(--light-blue);
   border-color: var(--light-blue);

--- a/website/styles.css
+++ b/website/styles.css
@@ -379,6 +379,56 @@ a {
   }
 }
 
+/* Animated wave field (waves.js). Sits at the bottom of the hero stacking
+   context; .hero-content and friends are z-index 1 and stay above it. */
+.hero-waves {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  /* Let clicks and text selection through — waves.js listens on .hero for
+     pointer parallax instead of on the canvas. */
+  pointer-events: none;
+  contain: strict;
+}
+
+.hero-waves-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* Contrast scrim between the canvas and the copy. The wave crests are near
+   white, so hero text needs a guaranteed dark ground under it to hold 4.5:1.
+   Only rendered once the canvas is actually live. */
+.hero-scrim {
+  display: none;
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(to right,
+      rgba(10, 10, 11, 0.94) 0%,
+      rgba(10, 10, 11, 0.78) 34%,
+      rgba(10, 10, 11, 0.34) 64%,
+      rgba(10, 10, 11, 0) 88%),
+    linear-gradient(to bottom,
+      rgba(10, 10, 11, 0.88) 0%,
+      rgba(10, 10, 11, 0) 24%,
+      rgba(10, 10, 11, 0) 58%,
+      rgba(10, 10, 11, 0.94) 100%);
+}
+
+.waves-active .hero-scrim {
+  display: block;
+}
+
+/* The CSS glow below is the fallback for no-JS / no-WebGL2 browsers, so it
+   only steps aside once the canvas has successfully taken over. */
+.waves-active .hero-glow {
+  display: none;
+}
+
 /* Soft irregular glow behind the headline */
 .hero-glow {
   position: absolute;
@@ -1130,6 +1180,16 @@ a {
     display: none;
   }
 
+  /* Copy is full-width from here down, so the scrim can no longer lean left */
+  .hero-scrim {
+    background:
+      linear-gradient(to bottom,
+        rgba(10, 10, 11, 0.9) 0%,
+        rgba(10, 10, 11, 0.62) 30%,
+        rgba(10, 10, 11, 0.62) 62%,
+        rgba(10, 10, 11, 0.95) 100%);
+  }
+
   .hero-content,
   .hero-blurb {
     margin-left: 0;
@@ -1219,5 +1279,221 @@ a {
 
   .glow-blob {
     animation: none;
+  }
+}
+
+/* ==========================================================================
+   Gradient waves tuning panel (dev only)
+   Markup is created by waves.js and only exists when the page is opened with
+   ?tune=1 (or #tune), so visitors never see or download this UI.
+   ========================================================================== */
+
+.waves-panel {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  bottom: 16px;
+  z-index: 9995;
+  width: 268px;
+  max-width: calc(100vw - 32px);
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  color: var(--text);
+  background: rgba(16, 16, 19, 0.94);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(12px);
+}
+
+.waves-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: 12px 8px 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.waves-panel-head h2 {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--primary-blue);
+}
+
+.waves-panel-close {
+  width: 28px;
+  height: 28px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  font-size: 18px;
+  line-height: 1;
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color var(--transition), background var(--transition);
+}
+
+.waves-panel-close:hover {
+  color: var(--text);
+  background: var(--surface-strong);
+}
+
+.waves-panel-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.waves-colors {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.waves-color {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.waves-color label {
+  color: var(--text-secondary);
+}
+
+.waves-color input[type="color"] {
+  width: 100%;
+  height: 30px;
+  padding: 0;
+  background: none;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.waves-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.waves-row-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.waves-row label {
+  color: var(--text-secondary);
+}
+
+.waves-value {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text);
+}
+
+.waves-row-select,
+.waves-row-toggle {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.waves-row-select {
+  justify-content: space-between;
+}
+
+.waves-panel select {
+  flex: 1 1 auto;
+  max-width: 120px;
+  padding: 5px 8px;
+  font: inherit;
+  color: var(--text);
+  background: var(--surface-strong);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.waves-panel input[type="range"] {
+  width: 100%;
+  accent-color: var(--primary-blue);
+  cursor: pointer;
+}
+
+.waves-panel input[type="checkbox"] {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--primary-blue);
+  cursor: pointer;
+}
+
+.waves-panel-actions {
+  display: flex;
+  gap: 8px;
+  padding: 12px 14px;
+  border-top: 1px solid var(--border);
+}
+
+.waves-btn {
+  flex: 1 1 auto;
+  padding: 8px 10px;
+  font: inherit;
+  font-weight: 500;
+  color: var(--text);
+  background: var(--surface-strong);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+.waves-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.waves-btn:active {
+  transform: scale(0.98);
+}
+
+.waves-btn-primary {
+  color: #08131f;
+  background: var(--light-blue);
+  border-color: var(--light-blue);
+}
+
+.waves-btn-primary:hover {
+  background: #c8ebff;
+}
+
+/* Focus ring meets the WCAG 2.2 focus-appearance target: 2px perimeter with
+   clear contrast against the panel surface. */
+.waves-panel :focus-visible {
+  outline: 2px solid var(--primary-blue);
+  outline-offset: 2px;
+}
+
+@media (max-width: 639px) {
+  .waves-panel {
+    top: auto;
+    left: 16px;
+    right: 16px;
+    bottom: 16px;
+    width: auto;
+    max-height: 62vh;
   }
 }

--- a/website/waves.js
+++ b/website/waves.js
@@ -18,49 +18,38 @@
    ========================================================================== */
 
 (function () {
-  'use strict';
+  "use strict";
 
   /* ------------------------------------------------------------------------
      Config — edit these
      ------------------------------------------------------------------------ */
 
   const WAVES_CONFIG = {
-    // Colors: token reference, hex, or rgb() string
-    horizonColor: 'var(--deep-blue)',    // distant haze the waves fade into
-    waveColor: 'var(--primary-blue)',    // mid color of the rolling bodies
-    crestColor: '#FFFFFF',               // highlight on the nearest crests
-
-    // Wave field
-    speed: 0.3,            // animation speed of the undulating field
-    amplitude: 3.0,         // height of the sine-plasma waves
-    waveScale: 0.5,         // overall spatial frequency
-    waveRatio: 0.9,         // ratio of short to long wavelength components
-    swell: 35,              // large-scale horizontal swell distortion
-    turbulence: 20,         // large-scale cross-flow turbulence
-
-    // Camera
-    tilt: 1.02,             // pitch toward the horizon, in radians
-    zoom: 1.0,              // field-of-view zoom into the field
-    height: 2.8,            // vertical offset of the horizon line
-    fogDepth: 32,           // distance over which waves fade into haze
-
-    // Appearance
-    detail: 'medium',       // raymarch quality: 'low' | 'medium' | 'high'
-    brightness: 1.5,        // final color multiplier
-    opacity: 1.0,           // global opacity of the effect
-
-    // Interaction
-    mouseInteraction: true, // pointer-driven camera parallax
-    parallaxStrength: 0.5,  // strength of the cursor drift
-
-    // Grain — off by default because styles.css already lays a film-grain
-    // overlay across the whole page; turning this on stacks a second one.
-    grain: false,
-    grainIntensity: 0.05,
-
-    // Performance ceiling for the render buffer. 2 is crisp on retina,
-    // 1.5 trades a little sharpness for noticeably fewer shaded pixels.
-    maxDpr: 2
+    horizonColor: "var(--deep-blue)",
+    waveColor: "var(--primary-blue)",
+    crestColor: "#FFFFFF",
+    speed: 0.3,
+    amplitude: 3.7,
+    waveScale: 0.5,
+    waveRatio: 0.9,
+    swell: 35,
+    turbulence: 20,
+    tilt: 1.02,
+    zoom: 1,
+    height: 2.8,
+    fogDepth: 32,
+    detail: "medium",
+    brightness: 1.5,
+    opacity: 1,
+    intro: true,
+    introZoomFrom: 0.43,
+    introStiffness: 60,
+    introDamping: 31,
+    mouseInteraction: false,
+    parallaxStrength: 0.5,
+    grain: true,
+    grainIntensity: 0.095,
+    maxDpr: 3,
   };
 
   /* ------------------------------------------------------------------------
@@ -187,7 +176,7 @@ void main() {
 
   // Accepts var(--token), #rgb, #rrggbb, rgb()/rgba(). Returns [r,g,b] in 0..1.
   function parseColor(value) {
-    let v = String(value == null ? '' : value).trim();
+    let v = String(value == null ? "" : value).trim();
 
     const token = TOKEN_RE.exec(v);
     if (token) {
@@ -201,7 +190,7 @@ void main() {
       return [
         parseInt(m[1] + m[1], 16) / 255,
         parseInt(m[2] + m[2], 16) / 255,
-        parseInt(m[3] + m[3], 16) / 255
+        parseInt(m[3] + m[3], 16) / 255,
       ];
     }
 
@@ -210,7 +199,7 @@ void main() {
       return [
         parseInt(m[1], 16) / 255,
         parseInt(m[2], 16) / 255,
-        parseInt(m[3], 16) / 255
+        parseInt(m[3], 16) / 255,
       ];
     }
 
@@ -219,7 +208,7 @@ void main() {
       return [
         Math.min(1, parseFloat(m[1]) / 255),
         Math.min(1, parseFloat(m[2]) / 255),
-        Math.min(1, parseFloat(m[3]) / 255)
+        Math.min(1, parseFloat(m[3]) / 255),
       ];
     }
 
@@ -228,19 +217,19 @@ void main() {
 
   function toHex(rgb) {
     return (
-      '#' +
+      "#" +
       rgb
         .map(function (channel) {
           const byte = Math.max(0, Math.min(255, Math.round(channel * 255)));
-          return byte.toString(16).padStart(2, '0');
+          return byte.toString(16).padStart(2, "0");
         })
-        .join('')
+        .join("")
     );
   }
 
   function detailToSteps(detail) {
-    if (detail === 'low') return 40.0;
-    if (detail === 'high') return 110.0;
+    if (detail === "low") return 40.0;
+    if (detail === "high") return 110.0;
     return 70.0;
   }
 
@@ -255,7 +244,7 @@ void main() {
     if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
       const log = gl.getShaderInfoLog(shader);
       gl.deleteShader(shader);
-      throw new Error('Shader compile failed: ' + log);
+      throw new Error("Shader compile failed: " + log);
     }
     return shader;
   }
@@ -272,7 +261,7 @@ void main() {
     if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
       const log = gl.getProgramInfoLog(program);
       gl.deleteProgram(program);
-      throw new Error('Program link failed: ' + log);
+      throw new Error("Program link failed: " + log);
     }
     return program;
   }
@@ -287,9 +276,9 @@ void main() {
     gl.bufferData(
       gl.ARRAY_BUFFER,
       new Float32Array([-1, -1, 3, -1, -1, 3]),
-      gl.STATIC_DRAW
+      gl.STATIC_DRAW,
     );
-    const loc = gl.getAttribLocation(program, 'position');
+    const loc = gl.getAttribLocation(program, "position");
     gl.enableVertexAttribArray(loc);
     gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
     gl.bindVertexArray(null);
@@ -301,42 +290,104 @@ void main() {
      ------------------------------------------------------------------------ */
 
   function createWaves(container, config) {
-    const canvas = document.createElement('canvas');
-    const gl = canvas.getContext('webgl2', {
+    const canvas = document.createElement("canvas");
+    const gl = canvas.getContext("webgl2", {
       alpha: true,
       premultipliedAlpha: true,
       antialias: false,
       depth: false,
       stencil: false,
-      powerPreference: 'default'
+      powerPreference: "default",
     });
     if (!gl) return null;
 
     const state = Object.assign({}, config);
-    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    // Entrance spring. It owns the uZoom uniform until it settles, after which
+    // state.zoom is used directly so panel edits respond instantly.
+    const zoomSpring = {
+      value: state.introZoomFrom,
+      velocity: 0,
+      active: false,
+    };
+
+    function effectiveZoom() {
+      return zoomSpring.active ? zoomSpring.value : state.zoom;
+    }
+
+    function startIntro() {
+      if (!state.intro || reduceMotion.matches) {
+        zoomSpring.active = false;
+        return;
+      }
+      zoomSpring.value = state.introZoomFrom;
+      zoomSpring.velocity = 0;
+      zoomSpring.active = true;
+    }
+
+    function endIntro() {
+      zoomSpring.active = false;
+    }
+
+    // Semi-implicit Euler. dt is clamped so a long stall — hidden tab, blocked
+    // main thread — can't fling the spring far past its target in one step.
+    function stepSpring(dt) {
+      if (!zoomSpring.active) return;
+      const step = Math.min(dt, 1 / 30);
+      const accel =
+        -state.introStiffness * (zoomSpring.value - state.zoom) -
+        state.introDamping * zoomSpring.velocity;
+      zoomSpring.velocity += accel * step;
+      zoomSpring.value += zoomSpring.velocity * step;
+      if (
+        Math.abs(zoomSpring.value - state.zoom) < 0.001 &&
+        Math.abs(zoomSpring.velocity) < 0.001
+      ) {
+        zoomSpring.active = false;
+      }
+    }
 
     let program, vao, uniforms;
     try {
       program = buildProgram(gl);
       vao = buildGeometry(gl, program);
     } catch (err) {
-      if (window.console) console.warn('[waves] ' + err.message);
+      if (window.console) console.warn("[waves] " + err.message);
       return null;
     }
 
     const UNIFORM_NAMES = [
-      'iResolution', 'iTime', 'uSpeed', 'uAmplitude', 'uWaveScale',
-      'uWaveRatio', 'uSwell', 'uTurbulence', 'uTilt', 'uZoom', 'uHeight',
-      'uFogDepth', 'uSteps', 'uBrightness', 'uOpacity', 'uGrain',
-      'uGrainIntensity', 'uMouse', 'uParallax', 'uEnableMouse',
-      'uHorizonColor', 'uWaveColor', 'uCrestColor'
+      "iResolution",
+      "iTime",
+      "uSpeed",
+      "uAmplitude",
+      "uWaveScale",
+      "uWaveRatio",
+      "uSwell",
+      "uTurbulence",
+      "uTilt",
+      "uZoom",
+      "uHeight",
+      "uFogDepth",
+      "uSteps",
+      "uBrightness",
+      "uOpacity",
+      "uGrain",
+      "uGrainIntensity",
+      "uMouse",
+      "uParallax",
+      "uEnableMouse",
+      "uHorizonColor",
+      "uWaveColor",
+      "uCrestColor",
     ];
     uniforms = {};
     UNIFORM_NAMES.forEach(function (name) {
       uniforms[name] = gl.getUniformLocation(program, name);
     });
 
-    canvas.className = 'hero-waves-canvas';
+    canvas.className = "hero-waves-canvas";
     container.appendChild(canvas);
 
     gl.clearColor(0, 0, 0, 0);
@@ -371,7 +422,7 @@ void main() {
       gl.uniform1f(uniforms.uSwell, state.swell);
       gl.uniform1f(uniforms.uTurbulence, state.turbulence);
       gl.uniform1f(uniforms.uTilt, state.tilt);
-      gl.uniform1f(uniforms.uZoom, state.zoom);
+      // uZoom is set per-frame in render() — the intro spring may own it.
       gl.uniform1f(uniforms.uHeight, state.height);
       gl.uniform1f(uniforms.uFogDepth, state.fogDepth);
       gl.uniform1f(uniforms.uSteps, detailToSteps(state.detail));
@@ -393,7 +444,7 @@ void main() {
 
     const current = [0.5, 0.5];
     const target = [0.5, 0.5];
-    const pointerHost = container.closest('.hero') || container;
+    const pointerHost = container.closest(".hero") || container;
 
     function onPointerMove(event) {
       if (!state.mouseInteraction) return;
@@ -408,12 +459,17 @@ void main() {
       target[1] = 0.5;
     }
 
-    pointerHost.addEventListener('pointermove', onPointerMove, { passive: true });
-    pointerHost.addEventListener('pointerleave', onPointerLeave, { passive: true });
+    pointerHost.addEventListener("pointermove", onPointerMove, {
+      passive: true,
+    });
+    pointerHost.addEventListener("pointerleave", onPointerLeave, {
+      passive: true,
+    });
 
     /* ---- render loop ---- */
 
     let raf = 0;
+    let prevNow = 0;
     let lastTime = 0;
     let onScreen = true;
     let pageVisible = !document.hidden;
@@ -427,12 +483,16 @@ void main() {
       gl.bindVertexArray(vao);
       gl.uniform2f(uniforms.iResolution, width, height);
       gl.uniform1f(uniforms.iTime, time);
+      gl.uniform1f(uniforms.uZoom, effectiveZoom());
       gl.uniform2f(uniforms.uMouse, current[0], current[1]);
       gl.clear(gl.COLOR_BUFFER_BIT);
       gl.drawArrays(gl.TRIANGLES, 0, 3);
     }
 
     function frame(now) {
+      const dt = prevNow ? (now - prevNow) * 0.001 : 0;
+      prevNow = now;
+      stepSpring(dt);
       const tx = state.mouseInteraction ? target[0] : 0.5;
       const ty = state.mouseInteraction ? target[1] : 0.5;
       current[0] += 0.05 * (tx - current[0]);
@@ -459,6 +519,7 @@ void main() {
         cancelAnimationFrame(raf);
         raf = 0;
       }
+      prevNow = 0;
     }
 
     /* ---- lifecycle observers ---- */
@@ -472,7 +533,7 @@ void main() {
         if (onScreen) start();
         else stop();
       },
-      { threshold: 0 }
+      { threshold: 0 },
     );
     intersectionObserver.observe(container);
 
@@ -481,38 +542,44 @@ void main() {
       if (pageVisible) start();
       else stop();
     }
-    document.addEventListener('visibilitychange', onVisibilityChange);
+    document.addEventListener("visibilitychange", onVisibilityChange);
 
     function onMotionPreferenceChange() {
       stop();
       start();
     }
-    if (typeof reduceMotion.addEventListener === 'function') {
-      reduceMotion.addEventListener('change', onMotionPreferenceChange);
+    if (typeof reduceMotion.addEventListener === "function") {
+      reduceMotion.addEventListener("change", onMotionPreferenceChange);
     }
 
     // A lost context (GPU reset, driver sleep) would otherwise leave a blank
     // canvas over the hero; drop back to the CSS glow instead.
-    canvas.addEventListener('webglcontextlost', function (event) {
+    canvas.addEventListener("webglcontextlost", function (event) {
       event.preventDefault();
       contextLost = true;
       stop();
-      document.documentElement.classList.remove('waves-active');
+      document.documentElement.classList.remove("waves-active");
     });
-    canvas.addEventListener('webglcontextrestored', function () {
+    canvas.addEventListener("webglcontextrestored", function () {
       contextLost = false;
-      document.documentElement.classList.add('waves-active');
+      document.documentElement.classList.add("waves-active");
       pushConfig();
       setSize();
       start();
     });
 
     pushConfig();
+    startIntro();
     setSize();
     start();
 
     return {
       state: state,
+      endIntro: endIntro,
+      replayIntro: function () {
+        startIntro();
+        start();
+      },
       apply: function (patch) {
         Object.assign(state, patch);
         pushConfig();
@@ -521,7 +588,7 @@ void main() {
       },
       redraw: function () {
         render(lastTime);
-      }
+      },
     };
   }
 
@@ -530,38 +597,60 @@ void main() {
      ------------------------------------------------------------------------ */
 
   const SLIDERS = [
-    { key: 'speed', label: 'Speed', min: 0, max: 2, step: 0.01 },
-    { key: 'amplitude', label: 'Amplitude', min: 0, max: 8, step: 0.05 },
-    { key: 'waveScale', label: 'Wave scale', min: 0.05, max: 2, step: 0.01 },
-    { key: 'waveRatio', label: 'Wave ratio', min: 0.1, max: 3, step: 0.01 },
-    { key: 'swell', label: 'Swell', min: 0, max: 100, step: 0.5 },
-    { key: 'turbulence', label: 'Turbulence', min: 0, max: 100, step: 0.5 },
-    { key: 'tilt', label: 'Tilt (rad)', min: 0, max: 3.14, step: 0.01 },
-    { key: 'zoom', label: 'Zoom', min: 0.1, max: 3, step: 0.01 },
-    { key: 'height', label: 'Horizon height', min: -20, max: 20, step: 0.1 },
-    { key: 'fogDepth', label: 'Fog depth', min: 1, max: 60, step: 0.5 },
-    { key: 'brightness', label: 'Brightness', min: 0, max: 2, step: 0.01 },
-    { key: 'opacity', label: 'Opacity', min: 0, max: 1, step: 0.01 },
-    { key: 'parallaxStrength', label: 'Parallax', min: 0, max: 2, step: 0.01 },
-    { key: 'grainIntensity', label: 'Grain intensity', min: 0, max: 0.3, step: 0.005 },
-    { key: 'maxDpr', label: 'Max DPR', min: 0.5, max: 3, step: 0.1 }
+    { key: "speed", label: "Speed", min: 0, max: 2, step: 0.01 },
+    { key: "amplitude", label: "Amplitude", min: 0, max: 8, step: 0.05 },
+    { key: "waveScale", label: "Wave scale", min: 0.05, max: 2, step: 0.01 },
+    { key: "waveRatio", label: "Wave ratio", min: 0.1, max: 3, step: 0.01 },
+    { key: "swell", label: "Swell", min: 0, max: 100, step: 0.5 },
+    { key: "turbulence", label: "Turbulence", min: 0, max: 100, step: 0.5 },
+    { key: "tilt", label: "Tilt (rad)", min: 0, max: 3.14, step: 0.01 },
+    { key: "zoom", label: "Zoom", min: 0.1, max: 3, step: 0.01 },
+    { key: "height", label: "Horizon height", min: -20, max: 20, step: 0.1 },
+    { key: "fogDepth", label: "Fog depth", min: 1, max: 60, step: 0.5 },
+    { key: "brightness", label: "Brightness", min: 0, max: 2, step: 0.01 },
+    { key: "opacity", label: "Opacity", min: 0, max: 1, step: 0.01 },
+    { key: "parallaxStrength", label: "Parallax", min: 0, max: 2, step: 0.01 },
+    {
+      key: "introZoomFrom",
+      label: "Intro zoom from",
+      min: 0.05,
+      max: 1,
+      step: 0.01,
+    },
+    {
+      key: "introStiffness",
+      label: "Intro stiffness",
+      min: 10,
+      max: 400,
+      step: 5,
+    },
+    { key: "introDamping", label: "Intro damping", min: 1, max: 60, step: 0.5 },
+    {
+      key: "grainIntensity",
+      label: "Grain intensity",
+      min: 0,
+      max: 0.3,
+      step: 0.005,
+    },
+    { key: "maxDpr", label: "Max DPR", min: 0.5, max: 3, step: 0.1 },
   ];
 
   const COLORS = [
-    { key: 'horizonColor', label: 'Horizon' },
-    { key: 'waveColor', label: 'Waves' },
-    { key: 'crestColor', label: 'Crests' }
+    { key: "horizonColor", label: "Horizon" },
+    { key: "waveColor", label: "Waves" },
+    { key: "crestColor", label: "Crests" },
   ];
 
   const TOGGLES = [
-    { key: 'mouseInteraction', label: 'Pointer parallax' },
-    { key: 'grain', label: 'Shader grain' }
+    { key: "intro", label: "Intro animation" },
+    { key: "mouseInteraction", label: "Pointer parallax" },
+    { key: "grain", label: "Shader grain" },
   ];
 
   // Browsers restore form-control values across reloads and would replay them
   // over WAVES_CONFIG, so every control here opts out of that restoration.
   function noRestore(input) {
-    input.autocomplete = 'off';
+    input.autocomplete = "off";
     return input;
   }
 
@@ -573,22 +662,35 @@ void main() {
   }
 
   function buildPanel(waves, defaults) {
-    const panel = el('aside', 'waves-panel');
-    panel.setAttribute('aria-label', 'Gradient waves controls');
+    const panel = el("aside", "waves-panel");
+    panel.setAttribute("aria-label", "Gradient waves controls");
 
-    const head = el('div', 'waves-panel-head');
-    head.appendChild(el('h2', null, 'Gradient waves'));
-    const close = el('button', 'waves-panel-close', '\u00d7');
-    close.type = 'button';
-    close.setAttribute('aria-label', 'Close controls');
-    close.addEventListener('click', function () {
+    const head = el("div", "waves-panel-head");
+    head.appendChild(el("h2", null, "Gradient waves"));
+    const close = el("button", "waves-panel-close", "\u00d7");
+    close.type = "button";
+    close.setAttribute("aria-label", "Close controls");
+    close.addEventListener("click", function () {
       panel.remove();
     });
     head.appendChild(close);
     panel.appendChild(head);
 
-    const body = el('div', 'waves-panel-body');
+    const body = el("div", "waves-panel-body");
     panel.appendChild(body);
+
+    // Any hands-on tuning ends the entrance animation, so a running spring
+    // never fights a value being dragged. Capture phase: fires before the
+    // per-control handlers below.
+    ["input", "change"].forEach(function (type) {
+      panel.addEventListener(
+        type,
+        function () {
+          waves.endIntro();
+        },
+        true,
+      );
+    });
 
     // key -> function(value) that writes a config value into its control.
     const sync = {};
@@ -596,20 +698,20 @@ void main() {
     let idSeq = 0;
     function nextId() {
       idSeq += 1;
-      return 'waves-ctl-' + idSeq;
+      return "waves-ctl-" + idSeq;
     }
 
     /* colors */
-    const colorRow = el('div', 'waves-colors');
+    const colorRow = el("div", "waves-colors");
     COLORS.forEach(function (def) {
       const id = nextId();
-      const wrap = el('div', 'waves-color');
-      const label = el('label', null, def.label);
+      const wrap = el("div", "waves-color");
+      const label = el("label", null, def.label);
       label.htmlFor = id;
-      const input = noRestore(document.createElement('input'));
-      input.type = 'color';
+      const input = noRestore(document.createElement("input"));
+      input.type = "color";
       input.id = id;
-      input.addEventListener('input', function () {
+      input.addEventListener("input", function () {
         const patch = {};
         patch[def.key] = input.value;
         waves.apply(patch);
@@ -625,18 +727,18 @@ void main() {
 
     /* detail select */
     const detailId = nextId();
-    const detailRow = el('div', 'waves-row waves-row-select');
-    const detailLabel = el('label', null, 'Detail');
+    const detailRow = el("div", "waves-row waves-row-select");
+    const detailLabel = el("label", null, "Detail");
     detailLabel.htmlFor = detailId;
-    const detailSelect = noRestore(document.createElement('select'));
+    const detailSelect = noRestore(document.createElement("select"));
     detailSelect.id = detailId;
-    ['low', 'medium', 'high'].forEach(function (tier) {
-      const option = document.createElement('option');
+    ["low", "medium", "high"].forEach(function (tier) {
+      const option = document.createElement("option");
       option.value = tier;
       option.textContent = tier;
       detailSelect.appendChild(option);
     });
-    detailSelect.addEventListener('change', function () {
+    detailSelect.addEventListener("change", function () {
       waves.apply({ detail: detailSelect.value });
     });
     sync.detail = function (value) {
@@ -649,13 +751,13 @@ void main() {
     /* toggles */
     TOGGLES.forEach(function (def) {
       const id = nextId();
-      const row = el('div', 'waves-row waves-row-toggle');
-      const input = noRestore(document.createElement('input'));
-      input.type = 'checkbox';
+      const row = el("div", "waves-row waves-row-toggle");
+      const input = noRestore(document.createElement("input"));
+      input.type = "checkbox";
       input.id = id;
-      const label = el('label', null, def.label);
+      const label = el("label", null, def.label);
       label.htmlFor = id;
-      input.addEventListener('change', function () {
+      input.addEventListener("change", function () {
         const patch = {};
         patch[def.key] = input.checked;
         waves.apply(patch);
@@ -671,18 +773,18 @@ void main() {
     /* sliders */
     SLIDERS.forEach(function (def) {
       const id = nextId();
-      const row = el('div', 'waves-row');
-      const label = el('label', null, def.label);
+      const row = el("div", "waves-row");
+      const label = el("label", null, def.label);
       label.htmlFor = id;
-      const output = el('output', 'waves-value');
+      const output = el("output", "waves-value");
       output.htmlFor = id;
-      const input = noRestore(document.createElement('input'));
-      input.type = 'range';
+      const input = noRestore(document.createElement("input"));
+      input.type = "range";
       input.id = id;
       input.min = String(def.min);
       input.max = String(def.max);
       input.step = String(def.step);
-      input.addEventListener('input', function () {
+      input.addEventListener("input", function () {
         const next = parseFloat(input.value);
         output.textContent = String(next);
         const patch = {};
@@ -693,7 +795,7 @@ void main() {
         input.value = String(value);
         output.textContent = String(value);
       };
-      const rowHead = el('div', 'waves-row-head');
+      const rowHead = el("div", "waves-row-head");
       rowHead.appendChild(label);
       rowHead.appendChild(output);
       row.appendChild(rowHead);
@@ -722,40 +824,53 @@ void main() {
     // pageshow fires after the browser has finished replaying remembered form
     // state (including on history and back/forward-cache loads), so this is
     // the point where re-asserting the config actually sticks.
-    window.addEventListener('pageshow', function () {
+    window.addEventListener("pageshow", function () {
       requestAnimationFrame(reassert);
     });
 
     /* actions */
-    const actions = el('div', 'waves-panel-actions');
+    const actions = el("div", "waves-panel-actions");
 
-    const copy = el('button', 'waves-btn waves-btn-primary', 'Copy config');
-    copy.type = 'button';
-    copy.addEventListener('click', function () {
+    const copy = el("button", "waves-btn waves-btn-primary", "Copy config");
+    copy.type = "button";
+    copy.addEventListener("click", function () {
       const text = serializeConfig(waves.state);
       const done = function (ok) {
-        copy.textContent = ok ? 'Copied' : 'Press \u2318C';
+        copy.textContent = ok ? "Copied" : "Press \u2318C";
         setTimeout(function () {
-          copy.textContent = 'Copy config';
+          copy.textContent = "Copy config";
         }, 1800);
       };
       if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard.writeText(text).then(
-          function () { done(true); },
-          function () { window.prompt('Copy this config:', text); done(false); }
+          function () {
+            done(true);
+          },
+          function () {
+            window.prompt("Copy this config:", text);
+            done(false);
+          },
         );
       } else {
-        window.prompt('Copy this config:', text);
+        window.prompt("Copy this config:", text);
         done(false);
       }
     });
     actions.appendChild(copy);
 
-    const reset = el('button', 'waves-btn', 'Reset');
-    reset.type = 'button';
-    reset.addEventListener('click', function () {
+    const replay = el("button", "waves-btn", "Replay intro");
+    replay.type = "button";
+    replay.addEventListener("click", function () {
+      waves.replayIntro();
+    });
+    actions.appendChild(replay);
+
+    const reset = el("button", "waves-btn", "Reset");
+    reset.type = "button";
+    reset.addEventListener("click", function () {
       waves.apply(defaults);
       syncAll(defaults);
+      waves.replayIntro();
     });
     actions.appendChild(reset);
 
@@ -766,18 +881,39 @@ void main() {
   // Emit a paste-ready block matching the WAVES_CONFIG shape above.
   function serializeConfig(state) {
     const order = [
-      'horizonColor', 'waveColor', 'crestColor', 'speed', 'amplitude',
-      'waveScale', 'waveRatio', 'swell', 'turbulence', 'tilt', 'zoom',
-      'height', 'fogDepth', 'detail', 'brightness', 'opacity',
-      'mouseInteraction', 'parallaxStrength', 'grain', 'grainIntensity',
-      'maxDpr'
+      "horizonColor",
+      "waveColor",
+      "crestColor",
+      "speed",
+      "amplitude",
+      "waveScale",
+      "waveRatio",
+      "swell",
+      "turbulence",
+      "tilt",
+      "zoom",
+      "height",
+      "fogDepth",
+      "detail",
+      "brightness",
+      "opacity",
+      "intro",
+      "introZoomFrom",
+      "introStiffness",
+      "introDamping",
+      "mouseInteraction",
+      "parallaxStrength",
+      "grain",
+      "grainIntensity",
+      "maxDpr",
     ];
     const lines = order.map(function (key) {
       const value = state[key];
-      const printed = typeof value === 'string' ? "'" + value + "'" : String(value);
-      return '  ' + key + ': ' + printed + ',';
+      const printed =
+        typeof value === "string" ? "'" + value + "'" : String(value);
+      return "  " + key + ": " + printed + ",";
     });
-    return 'const WAVES_CONFIG = {\n' + lines.join('\n') + '\n};';
+    return "const WAVES_CONFIG = {\n" + lines.join("\n") + "\n};";
   }
 
   /* ------------------------------------------------------------------------
@@ -785,17 +921,17 @@ void main() {
      ------------------------------------------------------------------------ */
 
   function init() {
-    const container = document.querySelector('.hero-waves');
+    const container = document.querySelector(".hero-waves");
     if (!container) return;
 
     const waves = createWaves(container, WAVES_CONFIG);
     if (!waves) return; // no WebGL2 — CSS glow fallback stays visible
 
-    document.documentElement.classList.add('waves-active');
+    document.documentElement.classList.add("waves-active");
 
     const tuning =
       /(^|[?&])tune=1(&|$)/.test(window.location.search) ||
-      window.location.hash === '#tune';
+      window.location.hash === "#tune";
     if (tuning) {
       buildPanel(waves, Object.assign({}, WAVES_CONFIG));
       // Handy for tweaking from the console: __waves.apply({ speed: 0.6 })
@@ -803,8 +939,8 @@ void main() {
     }
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
   } else {
     init();
   }

--- a/website/waves.js
+++ b/website/waves.js
@@ -1,0 +1,811 @@
+/* ==========================================================================
+   Wispr — hero gradient waves
+   --------------------------------------------------------------------------
+   Raymarched wave field rendered on a WebGL2 canvas behind the hero.
+   Ported from the React Bits <GradientWaves /> component to dependency-free
+   vanilla JS: the GLSL is unchanged, only the ogl scaffolding was rewritten
+   against the raw WebGL2 API. No build step, no imports, works over file://.
+
+   TUNING
+   ------
+   Edit WAVES_CONFIG below and reload, or open the page with ?tune=1 to get a
+   live control panel with sliders/pickers for every value plus a
+   "Copy config" button that emits a block you can paste straight back here.
+
+   Colors accept a token reference — var(--primary-blue) — resolved from the
+   custom properties in styles.css, so the palette stays defined in one place.
+   Plain #rrggbb, #rgb and rgb()/rgba() strings also work.
+   ========================================================================== */
+
+(function () {
+  'use strict';
+
+  /* ------------------------------------------------------------------------
+     Config — edit these
+     ------------------------------------------------------------------------ */
+
+  const WAVES_CONFIG = {
+    // Colors: token reference, hex, or rgb() string
+    horizonColor: 'var(--deep-blue)',    // distant haze the waves fade into
+    waveColor: 'var(--primary-blue)',    // mid color of the rolling bodies
+    crestColor: '#FFFFFF',               // highlight on the nearest crests
+
+    // Wave field
+    speed: 0.3,            // animation speed of the undulating field
+    amplitude: 3.0,         // height of the sine-plasma waves
+    waveScale: 0.5,         // overall spatial frequency
+    waveRatio: 0.9,         // ratio of short to long wavelength components
+    swell: 35,              // large-scale horizontal swell distortion
+    turbulence: 20,         // large-scale cross-flow turbulence
+
+    // Camera
+    tilt: 1.02,             // pitch toward the horizon, in radians
+    zoom: 1.0,              // field-of-view zoom into the field
+    height: 2.8,            // vertical offset of the horizon line
+    fogDepth: 32,           // distance over which waves fade into haze
+
+    // Appearance
+    detail: 'medium',       // raymarch quality: 'low' | 'medium' | 'high'
+    brightness: 1.5,        // final color multiplier
+    opacity: 1.0,           // global opacity of the effect
+
+    // Interaction
+    mouseInteraction: true, // pointer-driven camera parallax
+    parallaxStrength: 0.5,  // strength of the cursor drift
+
+    // Grain — off by default because styles.css already lays a film-grain
+    // overlay across the whole page; turning this on stacks a second one.
+    grain: false,
+    grainIntensity: 0.05,
+
+    // Performance ceiling for the render buffer. 2 is crisp on retina,
+    // 1.5 trades a little sharpness for noticeably fewer shaded pixels.
+    maxDpr: 2
+  };
+
+  /* ------------------------------------------------------------------------
+     Shaders — GLSL copied verbatim from the source component
+     ------------------------------------------------------------------------ */
+
+  const VERTEX = `#version 300 es
+in vec2 position;
+void main() {
+  gl_Position = vec4(position, 0.0, 1.0);
+}
+`;
+
+  const FRAGMENT = `#version 300 es
+precision highp float;
+uniform vec2 iResolution;
+uniform float iTime;
+uniform float uSpeed;
+uniform float uAmplitude;
+uniform float uWaveScale;
+uniform float uWaveRatio;
+uniform float uSwell;
+uniform float uTurbulence;
+uniform float uTilt;
+uniform float uZoom;
+uniform float uHeight;
+uniform float uFogDepth;
+uniform float uSteps;
+uniform float uBrightness;
+uniform float uOpacity;
+uniform float uGrain;
+uniform float uGrainIntensity;
+uniform vec2 uMouse;
+uniform float uParallax;
+uniform bool uEnableMouse;
+uniform vec3 uHorizonColor;
+uniform vec3 uWaveColor;
+uniform vec3 uCrestColor;
+out vec4 fragColor;
+
+const float MAX_DIST = 20000.0;
+
+float hash21(vec2 p) {
+  vec3 p3 = fract(vec3(p.xyx) * 0.1031);
+  p3 += dot(p3, p3.yzx + 33.33);
+  return fract((p3.x + p3.y) * p3.z);
+}
+
+float plasma(vec3 r, vec2 freq, vec4 tc) {
+  float mx = r.x + tc.x;
+  mx += uSwell * sin((r.y + mx) / 20.0 + tc.y);
+  float my = r.y - tc.z;
+  my += uTurbulence * cos(r.x / 23.0 + tc.w);
+  return r.z - (sin(mx * freq.x) * uAmplitude + sin(my * freq.y) * uAmplitude + uHeight);
+}
+
+float raymarch(vec3 pos, vec3 dir, vec2 freq, vec4 tc) {
+  float dist = 0.0;
+  for (int i = 0; i < 128; i++) {
+    if (float(i) >= uSteps) break;
+    float dscene = plasma(pos + dist * dir, freq, tc);
+    if (abs(dscene) < 0.1) break;
+    dist += 0.9 * dscene;
+    if (!(abs(dist) < MAX_DIST)) return MAX_DIST;
+  }
+  return dist;
+}
+
+void main() {
+  float T = iTime * uSpeed;
+  vec2 freq = vec2(uWaveScale / 7.0, (uWaveScale * uWaveRatio) / 3.0);
+  vec4 tc = vec4(T / 0.130, T / 0.810, T / 0.200, T / 0.710);
+  float c, s;
+  float vfov = (3.14159 / 2.3) / max(uZoom, 0.05);
+  vec3 cam = vec3(0.0, 0.0, 30.0);
+  vec2 uv = (gl_FragCoord.xy / iResolution.xy) - 0.5;
+  uv.x *= iResolution.x / iResolution.y;
+  uv.y *= -1.0;
+
+  vec3 dir = vec3(0.0, 0.0, -1.0);
+  float ulen = length(uv);
+  float xrot = vfov * ulen;
+  c = cos(xrot); s = sin(xrot);
+  dir = mat3(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c) * dir;
+  vec2 nuv = ulen > 1e-5 ? uv / ulen : vec2(1.0, 0.0);
+  c = nuv.x; s = nuv.y;
+  dir = mat3(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0) * dir;
+  c = cos(uTilt); s = sin(uTilt);
+  dir = mat3(c, 0.0, s, 0.0, 1.0, 0.0, -s, 0.0, c) * dir;
+
+  if (uEnableMouse) {
+    float yaw = (uMouse.x - 0.5) * uParallax * 0.4;
+    float pitch = (uMouse.y - 0.5) * uParallax * 0.4;
+    c = cos(yaw); s = sin(yaw);
+    dir = mat3(c, 0.0, s, 0.0, 1.0, 0.0, -s, 0.0, c) * dir;
+    c = cos(pitch); s = sin(pitch);
+    dir = mat3(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c) * dir;
+  }
+
+  float dist = raymarch(cam, dir, freq, tc);
+  vec3 pos = cam + dist * dir;
+
+  float t = clamp(uFogDepth / max(dist, 0.001), 0.0, 1.0);
+  vec3 body = mix(uWaveColor, uCrestColor, clamp(pos.z * 0.08 + 0.5, 0.0, 1.0));
+  vec3 col = mix(uHorizonColor, body, t);
+  col *= uBrightness;
+  col = clamp(col, 0.0, 1.0);
+
+  float alpha = clamp(t, 0.0, 1.0) * uOpacity;
+  if (uGrain > 0.5) {
+    float g = hash21(gl_FragCoord.xy + mod(iTime, 64.0) * 11.0);
+    alpha += (g - 0.5) * uGrainIntensity;
+  }
+  alpha = clamp(alpha, 0.0, 1.0);
+  fragColor = vec4(col * alpha, alpha);
+}
+`;
+
+  /* ------------------------------------------------------------------------
+     Color helpers
+     ------------------------------------------------------------------------ */
+
+  const TOKEN_RE = /^var\(\s*(--[\w-]+)\s*\)$/;
+
+  // Accepts var(--token), #rgb, #rrggbb, rgb()/rgba(). Returns [r,g,b] in 0..1.
+  function parseColor(value) {
+    let v = String(value == null ? '' : value).trim();
+
+    const token = TOKEN_RE.exec(v);
+    if (token) {
+      v = getComputedStyle(document.documentElement)
+        .getPropertyValue(token[1])
+        .trim();
+    }
+
+    let m = /^#([a-f\d])([a-f\d])([a-f\d])$/i.exec(v);
+    if (m) {
+      return [
+        parseInt(m[1] + m[1], 16) / 255,
+        parseInt(m[2] + m[2], 16) / 255,
+        parseInt(m[3] + m[3], 16) / 255
+      ];
+    }
+
+    m = /^#([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(v);
+    if (m) {
+      return [
+        parseInt(m[1], 16) / 255,
+        parseInt(m[2], 16) / 255,
+        parseInt(m[3], 16) / 255
+      ];
+    }
+
+    m = /^rgba?\(\s*([\d.]+)[\s,]+([\d.]+)[\s,]+([\d.]+)/i.exec(v);
+    if (m) {
+      return [
+        Math.min(1, parseFloat(m[1]) / 255),
+        Math.min(1, parseFloat(m[2]) / 255),
+        Math.min(1, parseFloat(m[3]) / 255)
+      ];
+    }
+
+    return [1, 1, 1];
+  }
+
+  function toHex(rgb) {
+    return (
+      '#' +
+      rgb
+        .map(function (channel) {
+          const byte = Math.max(0, Math.min(255, Math.round(channel * 255)));
+          return byte.toString(16).padStart(2, '0');
+        })
+        .join('')
+    );
+  }
+
+  function detailToSteps(detail) {
+    if (detail === 'low') return 40.0;
+    if (detail === 'high') return 110.0;
+    return 70.0;
+  }
+
+  /* ------------------------------------------------------------------------
+     WebGL2 setup
+     ------------------------------------------------------------------------ */
+
+  function compile(gl, type, source) {
+    const shader = gl.createShader(type);
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+      const log = gl.getShaderInfoLog(shader);
+      gl.deleteShader(shader);
+      throw new Error('Shader compile failed: ' + log);
+    }
+    return shader;
+  }
+
+  function buildProgram(gl) {
+    const vs = compile(gl, gl.VERTEX_SHADER, VERTEX);
+    const fs = compile(gl, gl.FRAGMENT_SHADER, FRAGMENT);
+    const program = gl.createProgram();
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      const log = gl.getProgramInfoLog(program);
+      gl.deleteProgram(program);
+      throw new Error('Program link failed: ' + log);
+    }
+    return program;
+  }
+
+  // Oversized triangle covering clip space — the fragment shader only reads
+  // gl_FragCoord, so a single primitive is enough to shade every pixel.
+  function buildGeometry(gl, program) {
+    const vao = gl.createVertexArray();
+    gl.bindVertexArray(vao);
+    const buffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([-1, -1, 3, -1, -1, 3]),
+      gl.STATIC_DRAW
+    );
+    const loc = gl.getAttribLocation(program, 'position');
+    gl.enableVertexAttribArray(loc);
+    gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+    gl.bindVertexArray(null);
+    return vao;
+  }
+
+  /* ------------------------------------------------------------------------
+     Instance
+     ------------------------------------------------------------------------ */
+
+  function createWaves(container, config) {
+    const canvas = document.createElement('canvas');
+    const gl = canvas.getContext('webgl2', {
+      alpha: true,
+      premultipliedAlpha: true,
+      antialias: false,
+      depth: false,
+      stencil: false,
+      powerPreference: 'default'
+    });
+    if (!gl) return null;
+
+    const state = Object.assign({}, config);
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    let program, vao, uniforms;
+    try {
+      program = buildProgram(gl);
+      vao = buildGeometry(gl, program);
+    } catch (err) {
+      if (window.console) console.warn('[waves] ' + err.message);
+      return null;
+    }
+
+    const UNIFORM_NAMES = [
+      'iResolution', 'iTime', 'uSpeed', 'uAmplitude', 'uWaveScale',
+      'uWaveRatio', 'uSwell', 'uTurbulence', 'uTilt', 'uZoom', 'uHeight',
+      'uFogDepth', 'uSteps', 'uBrightness', 'uOpacity', 'uGrain',
+      'uGrainIntensity', 'uMouse', 'uParallax', 'uEnableMouse',
+      'uHorizonColor', 'uWaveColor', 'uCrestColor'
+    ];
+    uniforms = {};
+    UNIFORM_NAMES.forEach(function (name) {
+      uniforms[name] = gl.getUniformLocation(program, name);
+    });
+
+    canvas.className = 'hero-waves-canvas';
+    container.appendChild(canvas);
+
+    gl.clearColor(0, 0, 0, 0);
+    gl.useProgram(program);
+    gl.bindVertexArray(vao);
+
+    /* ---- sizing ---- */
+
+    let width = 1;
+    let height = 1;
+
+    function setSize() {
+      const dpr = Math.min(window.devicePixelRatio || 1, state.maxDpr);
+      const rect = container.getBoundingClientRect();
+      width = Math.max(1, Math.floor(rect.width * dpr));
+      height = Math.max(1, Math.floor(rect.height * dpr));
+      if (canvas.width === width && canvas.height === height) return;
+      canvas.width = width;
+      canvas.height = height;
+      gl.viewport(0, 0, width, height);
+      render(lastTime);
+    }
+
+    /* ---- uniforms ---- */
+
+    function pushConfig() {
+      gl.useProgram(program);
+      gl.uniform1f(uniforms.uSpeed, state.speed);
+      gl.uniform1f(uniforms.uAmplitude, state.amplitude);
+      gl.uniform1f(uniforms.uWaveScale, state.waveScale);
+      gl.uniform1f(uniforms.uWaveRatio, state.waveRatio);
+      gl.uniform1f(uniforms.uSwell, state.swell);
+      gl.uniform1f(uniforms.uTurbulence, state.turbulence);
+      gl.uniform1f(uniforms.uTilt, state.tilt);
+      gl.uniform1f(uniforms.uZoom, state.zoom);
+      gl.uniform1f(uniforms.uHeight, state.height);
+      gl.uniform1f(uniforms.uFogDepth, state.fogDepth);
+      gl.uniform1f(uniforms.uSteps, detailToSteps(state.detail));
+      gl.uniform1f(uniforms.uBrightness, state.brightness);
+      gl.uniform1f(uniforms.uOpacity, state.opacity);
+      gl.uniform1f(uniforms.uGrain, state.grain ? 1.0 : 0.0);
+      gl.uniform1f(uniforms.uGrainIntensity, state.grainIntensity);
+      gl.uniform1f(uniforms.uParallax, state.parallaxStrength);
+      gl.uniform1i(uniforms.uEnableMouse, state.mouseInteraction ? 1 : 0);
+      gl.uniform3fv(uniforms.uHorizonColor, parseColor(state.horizonColor));
+      gl.uniform3fv(uniforms.uWaveColor, parseColor(state.waveColor));
+      gl.uniform3fv(uniforms.uCrestColor, parseColor(state.crestColor));
+    }
+
+    /* ---- pointer parallax ----
+       The canvas is pointer-events:none so hero text stays selectable, so the
+       listener lives on the hero section and coordinates are mapped onto the
+       canvas rect. Pointer events cover mouse, pen and touch alike. */
+
+    const current = [0.5, 0.5];
+    const target = [0.5, 0.5];
+    const pointerHost = container.closest('.hero') || container;
+
+    function onPointerMove(event) {
+      if (!state.mouseInteraction) return;
+      const rect = canvas.getBoundingClientRect();
+      if (!rect.width || !rect.height) return;
+      target[0] = (event.clientX - rect.left) / rect.width;
+      target[1] = 1.0 - (event.clientY - rect.top) / rect.height;
+    }
+
+    function onPointerLeave() {
+      target[0] = 0.5;
+      target[1] = 0.5;
+    }
+
+    pointerHost.addEventListener('pointermove', onPointerMove, { passive: true });
+    pointerHost.addEventListener('pointerleave', onPointerLeave, { passive: true });
+
+    /* ---- render loop ---- */
+
+    let raf = 0;
+    let lastTime = 0;
+    let onScreen = true;
+    let pageVisible = !document.hidden;
+    let contextLost = false;
+    const t0 = performance.now();
+
+    function render(time) {
+      if (contextLost) return;
+      lastTime = time;
+      gl.useProgram(program);
+      gl.bindVertexArray(vao);
+      gl.uniform2f(uniforms.iResolution, width, height);
+      gl.uniform1f(uniforms.iTime, time);
+      gl.uniform2f(uniforms.uMouse, current[0], current[1]);
+      gl.clear(gl.COLOR_BUFFER_BIT);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+    }
+
+    function frame(now) {
+      const tx = state.mouseInteraction ? target[0] : 0.5;
+      const ty = state.mouseInteraction ? target[1] : 0.5;
+      current[0] += 0.05 * (tx - current[0]);
+      current[1] += 0.05 * (ty - current[1]);
+      render((now - t0) * 0.001);
+      raf = requestAnimationFrame(frame);
+    }
+
+    function start() {
+      // Honour prefers-reduced-motion by holding a single still frame — the
+      // visual stays, the continuous motion does not.
+      if (reduceMotion.matches) {
+        stop();
+        render(lastTime);
+        return;
+      }
+      if (raf === 0 && onScreen && pageVisible && !contextLost) {
+        raf = requestAnimationFrame(frame);
+      }
+    }
+
+    function stop() {
+      if (raf !== 0) {
+        cancelAnimationFrame(raf);
+        raf = 0;
+      }
+    }
+
+    /* ---- lifecycle observers ---- */
+
+    const resizeObserver = new ResizeObserver(setSize);
+    resizeObserver.observe(container);
+
+    const intersectionObserver = new IntersectionObserver(
+      function (entries) {
+        onScreen = entries[0].isIntersecting;
+        if (onScreen) start();
+        else stop();
+      },
+      { threshold: 0 }
+    );
+    intersectionObserver.observe(container);
+
+    function onVisibilityChange() {
+      pageVisible = !document.hidden;
+      if (pageVisible) start();
+      else stop();
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    function onMotionPreferenceChange() {
+      stop();
+      start();
+    }
+    if (typeof reduceMotion.addEventListener === 'function') {
+      reduceMotion.addEventListener('change', onMotionPreferenceChange);
+    }
+
+    // A lost context (GPU reset, driver sleep) would otherwise leave a blank
+    // canvas over the hero; drop back to the CSS glow instead.
+    canvas.addEventListener('webglcontextlost', function (event) {
+      event.preventDefault();
+      contextLost = true;
+      stop();
+      document.documentElement.classList.remove('waves-active');
+    });
+    canvas.addEventListener('webglcontextrestored', function () {
+      contextLost = false;
+      document.documentElement.classList.add('waves-active');
+      pushConfig();
+      setSize();
+      start();
+    });
+
+    pushConfig();
+    setSize();
+    start();
+
+    return {
+      state: state,
+      apply: function (patch) {
+        Object.assign(state, patch);
+        pushConfig();
+        setSize();
+        if (raf === 0) render(lastTime);
+      },
+      redraw: function () {
+        render(lastTime);
+      }
+    };
+  }
+
+  /* ------------------------------------------------------------------------
+     Live control panel — only built when ?tune=1 (or #tune) is present
+     ------------------------------------------------------------------------ */
+
+  const SLIDERS = [
+    { key: 'speed', label: 'Speed', min: 0, max: 2, step: 0.01 },
+    { key: 'amplitude', label: 'Amplitude', min: 0, max: 8, step: 0.05 },
+    { key: 'waveScale', label: 'Wave scale', min: 0.05, max: 2, step: 0.01 },
+    { key: 'waveRatio', label: 'Wave ratio', min: 0.1, max: 3, step: 0.01 },
+    { key: 'swell', label: 'Swell', min: 0, max: 100, step: 0.5 },
+    { key: 'turbulence', label: 'Turbulence', min: 0, max: 100, step: 0.5 },
+    { key: 'tilt', label: 'Tilt (rad)', min: 0, max: 3.14, step: 0.01 },
+    { key: 'zoom', label: 'Zoom', min: 0.1, max: 3, step: 0.01 },
+    { key: 'height', label: 'Horizon height', min: -20, max: 20, step: 0.1 },
+    { key: 'fogDepth', label: 'Fog depth', min: 1, max: 60, step: 0.5 },
+    { key: 'brightness', label: 'Brightness', min: 0, max: 2, step: 0.01 },
+    { key: 'opacity', label: 'Opacity', min: 0, max: 1, step: 0.01 },
+    { key: 'parallaxStrength', label: 'Parallax', min: 0, max: 2, step: 0.01 },
+    { key: 'grainIntensity', label: 'Grain intensity', min: 0, max: 0.3, step: 0.005 },
+    { key: 'maxDpr', label: 'Max DPR', min: 0.5, max: 3, step: 0.1 }
+  ];
+
+  const COLORS = [
+    { key: 'horizonColor', label: 'Horizon' },
+    { key: 'waveColor', label: 'Waves' },
+    { key: 'crestColor', label: 'Crests' }
+  ];
+
+  const TOGGLES = [
+    { key: 'mouseInteraction', label: 'Pointer parallax' },
+    { key: 'grain', label: 'Shader grain' }
+  ];
+
+  // Browsers restore form-control values across reloads and would replay them
+  // over WAVES_CONFIG, so every control here opts out of that restoration.
+  function noRestore(input) {
+    input.autocomplete = 'off';
+    return input;
+  }
+
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text != null) node.textContent = text;
+    return node;
+  }
+
+  function buildPanel(waves, defaults) {
+    const panel = el('aside', 'waves-panel');
+    panel.setAttribute('aria-label', 'Gradient waves controls');
+
+    const head = el('div', 'waves-panel-head');
+    head.appendChild(el('h2', null, 'Gradient waves'));
+    const close = el('button', 'waves-panel-close', '\u00d7');
+    close.type = 'button';
+    close.setAttribute('aria-label', 'Close controls');
+    close.addEventListener('click', function () {
+      panel.remove();
+    });
+    head.appendChild(close);
+    panel.appendChild(head);
+
+    const body = el('div', 'waves-panel-body');
+    panel.appendChild(body);
+
+    // key -> function(value) that writes a config value into its control.
+    const sync = {};
+
+    let idSeq = 0;
+    function nextId() {
+      idSeq += 1;
+      return 'waves-ctl-' + idSeq;
+    }
+
+    /* colors */
+    const colorRow = el('div', 'waves-colors');
+    COLORS.forEach(function (def) {
+      const id = nextId();
+      const wrap = el('div', 'waves-color');
+      const label = el('label', null, def.label);
+      label.htmlFor = id;
+      const input = noRestore(document.createElement('input'));
+      input.type = 'color';
+      input.id = id;
+      input.addEventListener('input', function () {
+        const patch = {};
+        patch[def.key] = input.value;
+        waves.apply(patch);
+      });
+      sync[def.key] = function (value) {
+        input.value = toHex(parseColor(value));
+      };
+      wrap.appendChild(label);
+      wrap.appendChild(input);
+      colorRow.appendChild(wrap);
+    });
+    body.appendChild(colorRow);
+
+    /* detail select */
+    const detailId = nextId();
+    const detailRow = el('div', 'waves-row waves-row-select');
+    const detailLabel = el('label', null, 'Detail');
+    detailLabel.htmlFor = detailId;
+    const detailSelect = noRestore(document.createElement('select'));
+    detailSelect.id = detailId;
+    ['low', 'medium', 'high'].forEach(function (tier) {
+      const option = document.createElement('option');
+      option.value = tier;
+      option.textContent = tier;
+      detailSelect.appendChild(option);
+    });
+    detailSelect.addEventListener('change', function () {
+      waves.apply({ detail: detailSelect.value });
+    });
+    sync.detail = function (value) {
+      detailSelect.value = value;
+    };
+    detailRow.appendChild(detailLabel);
+    detailRow.appendChild(detailSelect);
+    body.appendChild(detailRow);
+
+    /* toggles */
+    TOGGLES.forEach(function (def) {
+      const id = nextId();
+      const row = el('div', 'waves-row waves-row-toggle');
+      const input = noRestore(document.createElement('input'));
+      input.type = 'checkbox';
+      input.id = id;
+      const label = el('label', null, def.label);
+      label.htmlFor = id;
+      input.addEventListener('change', function () {
+        const patch = {};
+        patch[def.key] = input.checked;
+        waves.apply(patch);
+      });
+      sync[def.key] = function (value) {
+        input.checked = Boolean(value);
+      };
+      row.appendChild(input);
+      row.appendChild(label);
+      body.appendChild(row);
+    });
+
+    /* sliders */
+    SLIDERS.forEach(function (def) {
+      const id = nextId();
+      const row = el('div', 'waves-row');
+      const label = el('label', null, def.label);
+      label.htmlFor = id;
+      const output = el('output', 'waves-value');
+      output.htmlFor = id;
+      const input = noRestore(document.createElement('input'));
+      input.type = 'range';
+      input.id = id;
+      input.min = String(def.min);
+      input.max = String(def.max);
+      input.step = String(def.step);
+      input.addEventListener('input', function () {
+        const next = parseFloat(input.value);
+        output.textContent = String(next);
+        const patch = {};
+        patch[def.key] = next;
+        waves.apply(patch);
+      });
+      sync[def.key] = function (value) {
+        input.value = String(value);
+        output.textContent = String(value);
+      };
+      const rowHead = el('div', 'waves-row-head');
+      rowHead.appendChild(label);
+      rowHead.appendChild(output);
+      row.appendChild(rowHead);
+      row.appendChild(input);
+      body.appendChild(row);
+    });
+
+    // Push a config object out to every control. Browsers replay their own
+    // remembered control values when a page is reloaded from history, which
+    // would otherwise leave the panel showing values the config never set —
+    // so this runs again after load, once that replay has happened.
+    function syncAll(source) {
+      Object.keys(sync).forEach(function (key) {
+        if (source[key] !== undefined) sync[key](source[key]);
+      });
+    }
+
+    // On a fresh load the config in this file is the source of truth, so the
+    // replayed values are re-overwritten in both directions: state and control.
+    function reassert() {
+      waves.apply(defaults);
+      syncAll(defaults);
+    }
+
+    syncAll(waves.state);
+    // pageshow fires after the browser has finished replaying remembered form
+    // state (including on history and back/forward-cache loads), so this is
+    // the point where re-asserting the config actually sticks.
+    window.addEventListener('pageshow', function () {
+      requestAnimationFrame(reassert);
+    });
+
+    /* actions */
+    const actions = el('div', 'waves-panel-actions');
+
+    const copy = el('button', 'waves-btn waves-btn-primary', 'Copy config');
+    copy.type = 'button';
+    copy.addEventListener('click', function () {
+      const text = serializeConfig(waves.state);
+      const done = function (ok) {
+        copy.textContent = ok ? 'Copied' : 'Press \u2318C';
+        setTimeout(function () {
+          copy.textContent = 'Copy config';
+        }, 1800);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(
+          function () { done(true); },
+          function () { window.prompt('Copy this config:', text); done(false); }
+        );
+      } else {
+        window.prompt('Copy this config:', text);
+        done(false);
+      }
+    });
+    actions.appendChild(copy);
+
+    const reset = el('button', 'waves-btn', 'Reset');
+    reset.type = 'button';
+    reset.addEventListener('click', function () {
+      waves.apply(defaults);
+      syncAll(defaults);
+    });
+    actions.appendChild(reset);
+
+    panel.appendChild(actions);
+    document.body.appendChild(panel);
+  }
+
+  // Emit a paste-ready block matching the WAVES_CONFIG shape above.
+  function serializeConfig(state) {
+    const order = [
+      'horizonColor', 'waveColor', 'crestColor', 'speed', 'amplitude',
+      'waveScale', 'waveRatio', 'swell', 'turbulence', 'tilt', 'zoom',
+      'height', 'fogDepth', 'detail', 'brightness', 'opacity',
+      'mouseInteraction', 'parallaxStrength', 'grain', 'grainIntensity',
+      'maxDpr'
+    ];
+    const lines = order.map(function (key) {
+      const value = state[key];
+      const printed = typeof value === 'string' ? "'" + value + "'" : String(value);
+      return '  ' + key + ': ' + printed + ',';
+    });
+    return 'const WAVES_CONFIG = {\n' + lines.join('\n') + '\n};';
+  }
+
+  /* ------------------------------------------------------------------------
+     Boot
+     ------------------------------------------------------------------------ */
+
+  function init() {
+    const container = document.querySelector('.hero-waves');
+    if (!container) return;
+
+    const waves = createWaves(container, WAVES_CONFIG);
+    if (!waves) return; // no WebGL2 — CSS glow fallback stays visible
+
+    document.documentElement.classList.add('waves-active');
+
+    const tuning =
+      /(^|[?&])tune=1(&|$)/.test(window.location.search) ||
+      window.location.hash === '#tune';
+    if (tuning) {
+      buildPanel(waves, Object.assign({}, WAVES_CONFIG));
+      // Handy for tweaking from the console: __waves.apply({ speed: 0.6 })
+      window.__waves = waves;
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/website/waves.js
+++ b/website/waves.js
@@ -45,11 +45,11 @@
     introZoomFrom: 0.43,
     introStiffness: 60,
     introDamping: 31,
-    mouseInteraction: false,
+    mouseInteraction: true,
     parallaxStrength: 0.5,
     grain: true,
     grainIntensity: 0.095,
-    maxDpr: 3,
+    maxDpr: 2,
   };
 
   /* ------------------------------------------------------------------------
@@ -311,6 +311,7 @@ void main() {
       velocity: 0,
       active: false,
     };
+    let introHeld = false;
 
     function effectiveZoom() {
       return zoomSpring.active ? zoomSpring.value : state.zoom;
@@ -324,6 +325,14 @@ void main() {
       zoomSpring.value = state.introZoomFrom;
       zoomSpring.velocity = 0;
       zoomSpring.active = true;
+      // While the load curtain is up the spring holds at its start value, so
+      // the zoom is already wide behind it and only begins integrating on
+      // wispr:reveal. With no curtain it runs straight away.
+      introHeld = document.documentElement.classList.contains("intro-armed");
+    }
+
+    function releaseIntro() {
+      introHeld = false;
     }
 
     function endIntro() {
@@ -333,7 +342,7 @@ void main() {
     // Semi-implicit Euler. dt is clamped so a long stall — hidden tab, blocked
     // main thread — can't fling the spring far past its target in one step.
     function stepSpring(dt) {
-      if (!zoomSpring.active) return;
+      if (!zoomSpring.active || introHeld) return;
       const step = Math.min(dt, 1 / 30);
       const accel =
         -state.introStiffness * (zoomSpring.value - state.zoom) -
@@ -469,6 +478,7 @@ void main() {
     /* ---- render loop ---- */
 
     let raf = 0;
+    let announced = false;
     let prevNow = 0;
     let lastTime = 0;
     let onScreen = true;
@@ -487,6 +497,10 @@ void main() {
       gl.uniform2f(uniforms.uMouse, current[0], current[1]);
       gl.clear(gl.COLOR_BUFFER_BIT);
       gl.drawArrays(gl.TRIANGLES, 0, 3);
+      if (!announced) {
+        announced = true;
+        document.dispatchEvent(new CustomEvent("wispr:waves-ready"));
+      }
     }
 
     function frame(now) {
@@ -576,8 +590,10 @@ void main() {
     return {
       state: state,
       endIntro: endIntro,
+      releaseIntro: releaseIntro,
       replayIntro: function () {
         startIntro();
+        releaseIntro();
         start();
       },
       apply: function (patch) {
@@ -928,6 +944,17 @@ void main() {
     if (!waves) return; // no WebGL2 — CSS glow fallback stays visible
 
     document.documentElement.classList.add("waves-active");
+
+    // The load curtain releases the zoom spring, so the background motion and
+    // the hero copy arrive together. If the intro was never armed — reduced
+    // motion, or a repeat visit already revealed — start immediately.
+    if (document.documentElement.classList.contains("intro-armed")) {
+      document.addEventListener("wispr:reveal", waves.releaseIntro, {
+        once: true,
+      });
+    } else {
+      waves.releaseIntro();
+    }
 
     const tuning =
       /(^|[?&])tune=1(&|$)/.test(window.location.search) ||


### PR DESCRIPTION
Full redesign of the marketing site — still static HTML/CSS/JS, no build step.

- Dark theme across all 9 sections, with new design tokens (color, type scale, spacing) at the top of `styles.css`
- New hero: WebGL2 animated wave field (`waves.js`) with a spring zoom on load, a loading curtain, and staggered entrance animations
- Rewritten `index.html` structure with semantic markup; carousel remains click/swipe/keyboard navigable
- Responsive at 375 / 768 / 1440px
- Updated `README.md` with deployment and customization docs; added `website/CLAUDE.md` with the design brief

Opening `index.html` directly still works.