### PR TITLE
fix(meeting): lay the window out as content, not a toolbar split view

### DIFF
--- a/Sources/WisprApp/UI/Meeting/MeetingTranscriptView.swift
+++ b/Sources/WisprApp/UI/Meeting/MeetingTranscriptView.swift
@@ -31,6 +31,11 @@ struct MeetingTranscriptView: View {
     /// Drives keyboard focus into the rename field the moment it appears, so the
     /// user can type immediately instead of having to click the field first.
     @FocusState private var speakerFieldFocused: Bool
+    /// Whether the history column is shown. Plain view state rather than a
+    /// `NavigationSplitView` column binding: this window is a utility `NSPanel`
+    /// with no `NSToolbar`, so the split view's own chrome cannot render into a
+    /// title bar and lands in the content area instead.
+    @State private var showHistory = true
 
     // MARK: - Displayed transcript
 
@@ -46,32 +51,14 @@ struct MeetingTranscriptView: View {
     private var isArchived: Bool { history.isShowingArchived }
 
     var body: some View {
-        NavigationSplitView {
-            MeetingHistorySidebar()
-                .navigationSplitViewColumnWidth(min: 190, ideal: 210, max: 280)
-        } detail: {
-            detailPane
-        }
-        // Start/Stop lives in the toolbar, next to the sidebar-collapse button,
-        // so it stays reachable from anywhere (live or archived) at the very top.
-        .toolbar {
-            ToolbarItem(placement: .navigation) {
-                Button {
-                    Task { await meetingState.toggleMeeting() }
-                } label: {
-                    Label(
-                        meetingState.meetingState == .recording ? "Stop" : "Start Meeting",
-                        systemImage: meetingState.meetingState == .recording
-                            ? SFSymbols.stopFill
-                            : SFSymbols.recordingMicrophone
-                    )
-                    .labelStyle(.titleAndIcon)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(meetingState.meetingState == .recording ? .red : theme.accentColor)
-                .accessibilityLabel(
-                    meetingState.meetingState == .recording ? "Stop meeting" : "Start meeting")
+        HStack(spacing: 0) {
+            if showHistory {
+                MeetingHistorySidebar()
+                    .frame(minWidth: 190, idealWidth: 210, maxWidth: 280)
+                Divider()
             }
+
+            detailPane
         }
         // Sized for sidebar + transcript: the rows spend ~154pt on the timestamp
         // and speaker columns before any text, so a narrower window leaves the
@@ -91,20 +78,13 @@ struct MeetingTranscriptView: View {
 
     private var detailPane: some View {
         VStack(spacing: 0) {
-            if showsHeader {
-                headerBar
-            }
+            headerBar
 
             if let message = history.errorMessage {
                 errorBanner(message)
             }
 
-            // Only draw the top divider when something sits above it; otherwise
-            // an idle "Current Session" would show an empty bar and stray rule
-            // now that Start/Stop lives in the toolbar.
-            if showsHeader || history.errorMessage != nil {
-                Divider()
-            }
+            Divider()
 
             if transcript.entries.isEmpty {
                 emptyState
@@ -121,10 +101,6 @@ struct MeetingTranscriptView: View {
     /// The header shows the archived session's title or the live recording
     /// indicators; when the live session is idle it has nothing to show, so it
     /// (and its divider) are hidden rather than left as an empty bar.
-    private var showsHeader: Bool {
-        isArchived || meetingState.meetingState == .recording
-    }
-
     private var exportFilename: String {
         guard isArchived else { return "meeting-transcript" }
         let stamp = MeetingTranscript.formatTime(transcript.startTime)
@@ -159,6 +135,51 @@ struct MeetingTranscriptView: View {
 
     private var headerBar: some View {
         HStack(spacing: 12) {
+            // History toggle, first in the row so it holds one position whether
+            // the sidebar is open or closed.
+            Button {
+                showHistory.toggle()
+            } label: {
+                Image(systemName: "sidebar.left")
+                    .font(.body)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+                    .background(showHistory ? theme.accentColor.opacity(0.15) : Color.clear)
+                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .help(showHistory ? "Hide transcript history" : "Show transcript history")
+            .accessibilityLabel("Toggle transcript history")
+
+            // Start/Stop sits in the header rather than the transcript body, so
+            // it stays reachable while an archived session is on screen.
+            Button {
+                Task { await meetingState.toggleMeeting() }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(
+                        systemName: meetingState.meetingState == .recording
+                            ? SFSymbols.stopFill
+                            : SFSymbols.recordingMicrophone
+                    )
+                    .font(.body)
+
+                    Text(meetingState.meetingState == .recording ? "Stop" : "Start Meeting")
+                        .font(.callout.weight(.medium))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(
+                    meetingState.meetingState == .recording
+                        ? Color.red.opacity(0.15)
+                        : theme.accentColor.opacity(0.15)
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(
+                meetingState.meetingState == .recording ? "Stop meeting" : "Start meeting")
+
             if isArchived {
                 archivedHeaderContent
             } else {


### PR DESCRIPTION
## Summary

Follow-up to #88, which merged as `17bc9da`. One commit on top of `main`, touching only `MeetingTranscriptView.swift`.

Fixes the meeting window's layout: the sidebar toggle jumped position when collapsing/expanding, and the toolbar chrome rendered inside the content area instead of a title bar.

## What's wrong

The meeting window is an `NSPanel` built with `[.titled, .closable, .resizable, .nonactivatingPanel, .utilityWindow]`. It has no `NSToolbar`, no `.fullSizeContentView`, and no `toolbarStyle` — there is no `NSToolbar` anywhere in the app.

`NavigationSplitView` with `.toolbar { ToolbarItem(placement: .navigation) }` has no title bar to render into in that kind of panel, so its chrome ends up in the content area instead:

- a second bar under the window title, with a full-width rule beneath it
- the sidebar starting below that strip instead of running the window's full height
- `.listStyle(.sidebar)` drawn as an inset rounded panel with gutters on the left and bottom

That's also why the sidebar's collapse button relocated: it was the split view's own system-supplied toggle, and it moves to the trailing edge of the title bar once the sidebar collapses. It isn't something the view code can pin in place, because it isn't the view's own button.

## What this changes

Laid out as plain content, the window fills edge to edge as it did before #88:

- `HStack` with the sidebar and a divider. The width constraint the split-view column used to supply (`minWidth: 190, idealWidth: 210, maxWidth: 280`) moves onto the sidebar directly.
- The sidebar toggle and Start/Stop return to an in-content header bar, toggle first so it holds one fixed position whether the sidebar is open or closed. Start/Stop keeps the toolbar-era placement — reachable while an archived transcript is on screen — and goes back to the plain, softly tinted rounded-rect button, red-tinted while recording, rather than `.borderedProminent`.
- `showsHeader` is removed. It hid an empty header while the live session was idle, which was only empty because Start/Stop had moved to the toolbar.

Nothing below the UI is touched: the transcript store, sidebar rows and context menus, multi-select and batch delete, session/speaker naming, and the directory watcher are all unchanged.

An alternative would be to make the panel host a real `NSToolbar` — add `.fullSizeContentView`, drop `.utilityWindow`, attach a `.unified`-style toolbar. I stayed away from that: the panel is deliberately `.nonactivatingPanel` and floating so a menu-bar app's window doesn't steal focus, and that combination with a real toolbar is where focus regressions tend to come from.

## Testing

- `swift build --target WisprApp`: clean.
- `swift test`: 613 tests, all passing (including `AudioEngine audio level stream terminates on stop`, which had been flaky in a full run on this machine before — clean this time).
- Verified by eye on a signed local Release build: sidebar toggle stays in place across several collapse/expand cycles, Start/Stop keeps its old styling, and the window fills edge to edge with no stray toolbar bar.

<img width="687" height="590" alt="image" src="https://github.com/user-attachments/assets/c6b5dfde-b534-471b-8eec-07abebb41dfa" />

