### PR TITLE
fix: restore test target recipe in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,8 @@ which-app: ## Show which Wispr bundle is running, and what it was built from
 	@$(LSREGISTER) -dump 2>/dev/null \
 		| awk '/^bundle[ \t]/{p=""} /path:/{p=$$2} /$(BUNDLE_ID)/{if(p!="")print "  "p}' | sort -u
 
-test: ## Run unit tests with xcodebuild (not SPM)	set -o pipefail && xcodebuild test \
+test: ## Run unit tests with xcodebuild (not SPM)
+	set -o pipefail && xcodebuild test \
 		-project $(XCODEPROJ) \
 		-scheme $(SCHEME) \
 		-configuration Debug \


### PR DESCRIPTION
The `test:` recipe was folded onto the target line after the `##` help comment. Since `##` is a Makefile comment that extends to the end of the logical line (including backslash continuations), the entire `xcodebuild test` pipeline was treated as a comment — making `make test` a silent no-op.

Fixed by putting the recipe back on its own tab-indented line.

**Verified locally:**
```
$ make -n test
set -o pipefail && xcodebuild test \
    -project wispr.xcodeproj \
    -scheme wispr \
    ...
```

Fixes #94