### PR TITLE
fix(meeting): structured concurrency, cached listing, no scope leak (#93)

### DIFF
--- a/Sources/WisprApp/Services/MeetingHistoryStore.swift
+++ b/Sources/WisprApp/Services/MeetingHistoryStore.swift
@@ -68,7 +68,7 @@ final class MeetingHistoryStore {
         isLoading = true
         defer { isLoading = false }
 
-        let scanned = await Task.detached { TranscriptStore.list() }.value
+        let scanned = await TranscriptIO.shared.list()
         summaries = scanned
 
         // A transcript deleted outside the app (or by another window) must not
@@ -100,9 +100,12 @@ final class MeetingHistoryStore {
         errorMessage = nil
 
         let url = summary.url
-        let result = await Task.detached { () -> Result<MeetingTranscript, any Error> in
-            do { return .success(try TranscriptStore.load(url)) } catch { return .failure(error) }
-        }.value
+        let result: Result<MeetingTranscript, any Error>
+        do {
+            result = .success(try await TranscriptIO.shared.load(url))
+        } catch {
+            result = .failure(error)
+        }
 
         switch result {
         case .success(let transcript):
@@ -129,21 +132,20 @@ final class MeetingHistoryStore {
 
         // Edit the file rather than `loadedTranscript`: a session can be renamed
         // from the sidebar without being opened first.
-        let outcome = await Task.detached { () -> Result<(MeetingTranscript, URL), any Error> in
-            do {
-                var transcript = try TranscriptStore.load(url)
-                transcript.setTitle(title)
-                try TranscriptStore.save(transcript, to: url)
-                // Rename only after the content is safely written: a failed rename
-                // then leaves a correctly-titled file under its old name, rather
-                // than a renamed file holding a stale title.
-                let renamed = try TranscriptStore.rename(
-                    at: url, startTime: transcript.startTime, title: transcript.title)
-                return .success((transcript, renamed))
-            } catch {
-                return .failure(error)
-            }
-        }.value
+        let outcome: Result<(MeetingTranscript, URL), any Error>
+        do {
+            var transcript = try await TranscriptIO.shared.load(url)
+            transcript.setTitle(title)
+            try await TranscriptIO.shared.save(transcript, to: url)
+            // Rename only after the content is safely written: a failed rename
+            // then leaves a correctly-titled file under its old name, rather
+            // than a renamed file holding a stale title.
+            let renamed = try await TranscriptIO.shared.rename(
+                at: url, startTime: transcript.startTime, title: transcript.title)
+            outcome = .success((transcript, renamed))
+        } catch {
+            outcome = .failure(error)
+        }
 
         switch outcome {
         case .success(let (transcript, renamedURL)):
@@ -173,14 +175,13 @@ final class MeetingHistoryStore {
         loadedTranscript = transcript
 
         let snapshot = transcript
-        let failure = await Task.detached { () -> (any Error)? in
-            do {
-                try TranscriptStore.save(snapshot, to: url)
-                return nil
-            } catch {
-                return error
-            }
-        }.value
+        let failure: (any Error)?
+        do {
+            try await TranscriptIO.shared.save(snapshot, to: url)
+            failure = nil
+        } catch {
+            failure = error
+        }
 
         if let failure {
             Log.stateManager.error(
@@ -207,17 +208,14 @@ final class MeetingHistoryStore {
         guard !summaries.isEmpty else { return }
         let urls = summaries.map(\.url)
 
-        let failures = await Task.detached { () -> [String] in
-            var failures: [String] = []
-            for url in urls {
-                do {
-                    try TranscriptStore.delete(url)
-                } catch {
-                    failures.append("\(url.lastPathComponent) (\(error.localizedDescription))")
-                }
+        var failures: [String] = []
+        for url in urls {
+            do {
+                try await TranscriptIO.shared.delete(url)
+            } catch {
+                failures.append("\(url.lastPathComponent) (\(error.localizedDescription))")
             }
-            return failures
-        }.value
+        }
 
         // Drop the viewer off a transcript that no longer exists before rescanning.
         if let loaded = loadedURL, urls.contains(loaded) { showLive() }

--- a/Sources/WisprApp/Services/MeetingStateManager.swift
+++ b/Sources/WisprApp/Services/MeetingStateManager.swift
@@ -189,7 +189,7 @@ final class MeetingStateManager {
         // writing happen off the main actor, but are awaited so the save is
         // guaranteed to complete before `transcript` can be replaced.
         let completed = transcript
-        let savedURL = await Task.detached { TranscriptStore.save(completed) }.value
+        let savedURL = await TranscriptIO.shared.save(completed)
 
         // Return "Current Session" to an empty slate: the finished meeting is now
         // on disk and shown from history, so keeping its text in the live view

--- a/Sources/WisprApp/Services/TranscriptLocation.swift
+++ b/Sources/WisprApp/Services/TranscriptLocation.swift
@@ -126,6 +126,18 @@ nonisolated enum TranscriptLocation {
             return .failed(error.localizedDescription)
         }
 
+        // Re-activating the folder that is already current — re-picking it in
+        // Settings, or `applyStoredFolder` running again for an already-active
+        // folder — must not call `startAccessingSecurityScopedResource()` a
+        // second time. `replaceScope` only balances a *change* of URL with a
+        // matching `stop`, so a second `start` on the same URL would leak one
+        // retained access count with nothing left to close it.
+        let alreadyActive = scope.withLock { $0?.holdsSecurityScope == true && $0?.url == resolved }
+        if alreadyActive {
+            let refreshed = isStale ? try? makeBookmark(for: resolved) : nil
+            return .activated(resolved, refreshedBookmark: refreshed)
+        }
+
         guard resolved.startAccessingSecurityScopedResource() else {
             useDefault()
             return .failed("macOS denied access to “\(resolved.lastPathComponent)”.")

--- a/Sources/WisprApp/Services/TranscriptStore.swift
+++ b/Sources/WisprApp/Services/TranscriptStore.swift
@@ -50,9 +50,16 @@ nonisolated struct TranscriptSummary: Identifiable, Sendable, Equatable {
 /// one — which resets the in-memory transcript — never destroys prior data.
 ///
 /// The whole type is `nonisolated` so that directory scans, decoding, and file
-/// writes never run on the main actor. Under this package's
+/// writes never run on the main actor by default. Under this package's
 /// `.defaultIsolation(MainActor.self)` the default would be the opposite:
 /// listing a hundred transcripts would decode them all on the UI thread.
+///
+/// This only makes the *type* callable off the main actor — it does not by
+/// itself move a caller's work anywhere. Call through `TranscriptIO` (below)
+/// to actually hop off the main actor via a structured `await` rather than
+/// `Task.detached`. `finalizeForTermination()` is the one exception: it runs
+/// synchronously from `applicationWillTerminate`, which cannot `await`, so it
+/// calls these static members directly.
 nonisolated enum TranscriptStore {
 
     /// Directory where transcript JSON files are stored.
@@ -321,5 +328,50 @@ nonisolated enum TranscriptStore {
 
     private static func fileCreationDate(_ url: URL) -> Date? {
         try? url.resourceValues(forKeys: [.creationDateKey]).creationDate
+    }
+}
+
+/// Runs `TranscriptStore`'s file I/O off the main actor through a real
+/// structured-concurrency boundary.
+///
+/// `TranscriptStore` itself is a `nonisolated enum` of `static` members, so
+/// there is no instance for actor isolation to attach to — it cannot become
+/// an `actor` in the usual sense. This actor exists to give callers something
+/// to `await` into instead: unlike `Task.detached`, an `await` on an actor
+/// method inherits the caller's priority, task-local values, and cancellation
+/// (see CLAUDE.md's "Structured concurrency only" rule under Concurrency
+/// Patterns).
+///
+/// `TranscriptStore`'s own file operations stay synchronous: they are the
+/// right shape for `finalizeForTermination()`, which runs from
+/// `applicationWillTerminate` and cannot `await` at all.
+actor TranscriptIO {
+    static let shared = TranscriptIO()
+
+    private init() {}
+
+    func list() -> [TranscriptSummary] {
+        TranscriptStore.list()
+    }
+
+    func load(_ url: URL) throws -> MeetingTranscript {
+        try TranscriptStore.load(url)
+    }
+
+    @discardableResult
+    func save(_ transcript: MeetingTranscript) -> URL? {
+        TranscriptStore.save(transcript)
+    }
+
+    func save(_ transcript: MeetingTranscript, to url: URL) throws {
+        try TranscriptStore.save(transcript, to: url)
+    }
+
+    func delete(_ url: URL) throws {
+        try TranscriptStore.delete(url)
+    }
+
+    func rename(at url: URL, startTime: Date, title: String?) throws -> URL {
+        try TranscriptStore.rename(at: url, startTime: startTime, title: title)
     }
 }

--- a/Sources/WisprApp/Services/TranscriptStore.swift
+++ b/Sources/WisprApp/Services/TranscriptStore.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Synchronization
 import WisprCore
 import os
 
@@ -142,6 +143,22 @@ nonisolated enum TranscriptStore {
 
     // MARK: - Reading
 
+    /// Summaries already computed, keyed by file URL and tagged with the file's
+    /// modification date at the time they were built.
+    ///
+    /// `list()` runs on every window appear, after each rename/retitle/delete, on
+    /// debounced external filesystem changes, and on meeting stop, so its cost
+    /// scales with total transcribed minutes across every saved session and
+    /// repeats often. A summary only needs a preview line, entry count, duration,
+    /// and speaker names, but building one from scratch decodes the whole
+    /// transcript — every entry — which is exactly the cost `TranscriptSummary`
+    /// exists to avoid paying just to list. Keying by mtime rather than trusting
+    /// the cache unconditionally means an edit made outside this cache — Finder,
+    /// another process, a future code path that writes the file directly — is
+    /// picked up on the next scan instead of serving a stale summary forever.
+    private static let summaryCache = Mutex<[URL: (modified: Date, summary: TranscriptSummary)]>(
+        [:])
+
     /// All saved transcripts, most recent first.
     ///
     /// A file that cannot be decoded yields a summary with `isUnreadable = true`
@@ -152,7 +169,7 @@ nonisolated enum TranscriptStore {
         guard
             let urls = try? fileManager.contentsOfDirectory(
                 at: directory,
-                includingPropertiesForKeys: [.creationDateKey],
+                includingPropertiesForKeys: [.creationDateKey, .contentModificationDateKey],
                 options: [.skipsHiddenFiles]
             )
         else {
@@ -160,13 +177,27 @@ nonisolated enum TranscriptStore {
             return []
         }
 
-        return urls
-            .filter {
-                $0.pathExtension == fileExtension
-                    && $0.lastPathComponent.hasPrefix(filePrefix)
-            }
-            .map(summary(for:))
+        let candidates = urls.filter {
+            $0.pathExtension == fileExtension && $0.lastPathComponent.hasPrefix(filePrefix)
+        }
+
+        return candidates
+            .map(cachedSummary(for:))
             .sorted { $0.startTime > $1.startTime }
+    }
+
+    /// Returns a cached summary for `url` when its modification date matches what
+    /// was cached, otherwise decodes the file and caches the result.
+    private static func cachedSummary(for url: URL) -> TranscriptSummary {
+        let modified = fileModificationDate(url) ?? .distantPast
+
+        if let cached = summaryCache.withLock({ $0[url] }), cached.modified == modified {
+            return cached.summary
+        }
+
+        let built = summary(for: url)
+        summaryCache.withLock { $0[url] = (modified, built) }
+        return built
     }
 
     /// Loads a full transcript from disk.
@@ -178,6 +209,7 @@ nonisolated enum TranscriptStore {
     /// Permanently deletes a transcript file.
     static func delete(_ url: URL) throws {
         try FileManager.default.removeItem(at: url)
+        summaryCache.withLock { $0[url] = nil }
         Log.stateManager.debug("TranscriptStore — deleted \(url.lastPathComponent)")
     }
 
@@ -196,9 +228,37 @@ nonisolated enum TranscriptStore {
         guard target != url else { return url }
 
         try FileManager.default.moveItem(at: url, to: target)
+        // The cache is keyed by URL, so the entry under the old URL has to move
+        // with the file or the next `list()` would treat the new URL as an
+        // uncached miss and decode a file whose content — and so summary — did
+        // not actually change; `moveItem` preserves the modification date, so the
+        // carried entry's staleness check still holds under the new URL. Dropping
+        // the old URL's entry either way also prevents it being served if that
+        // path is ever reused (a rename back to a previous title).
+        summaryCache.withLock { cache in
+            let carried = cache.removeValue(forKey: url)
+            if let carried {
+                cache[target] = (carried.modified, retargeted(carried.summary, to: target))
+            }
+        }
         Log.stateManager.debug(
             "TranscriptStore — renamed \(url.lastPathComponent) to \(target.lastPathComponent)")
         return target
+    }
+
+    /// Copies a summary onto a new URL, for carrying a cache entry across a
+    /// rename where the file's content — and so every other field — is unchanged.
+    private static func retargeted(_ summary: TranscriptSummary, to url: URL) -> TranscriptSummary {
+        TranscriptSummary(
+            url: url,
+            startTime: summary.startTime,
+            title: summary.title,
+            duration: summary.duration,
+            entryCount: summary.entryCount,
+            speakerNames: summary.speakerNames,
+            preview: summary.preview,
+            isUnreadable: summary.isUnreadable
+        )
     }
 
     /// Converts a session title into a filename-safe fragment.
@@ -244,6 +304,16 @@ nonisolated enum TranscriptStore {
             at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         let data = try encoder.encode(transcript)
         try data.write(to: url, options: .atomic)
+
+        // Populate the cache from the transcript already in hand, rather than
+        // leaving the next `list()` to decode the file this call just wrote.
+        // Not required for correctness — `cachedSummary(for:)`'s own mtime check
+        // already invalidates correctly on a fresh `URL` from
+        // `contentsOfDirectory`, which is what `list()` uses — but it avoids
+        // decoding a transcript that is, at this point, already sitting in memory.
+        let built = summary(from: transcript, url: url)
+        let modified = fileModificationDate(url) ?? .distantPast
+        summaryCache.withLock { $0[url] = (modified, built) }
     }
 
     /// Builds a unique file URL for a session start time and optional title.
@@ -309,7 +379,15 @@ nonisolated enum TranscriptStore {
                 isUnreadable: true
             )
         }
+        return summary(from: transcript, url: url)
+    }
 
+    /// Builds a summary from a transcript already decoded in memory.
+    ///
+    /// Split out from `summary(for:)` so `write(_:to:)` can refresh the cache
+    /// from the transcript it just encoded, instead of re-reading and
+    /// re-decoding the file it only just wrote.
+    private static func summary(from transcript: MeetingTranscript, url: URL) -> TranscriptSummary {
         let names = transcript.presentSpeakerIndices.map { index in
             transcript.displayName(for: .others(speakerIndex: index))
         }
@@ -328,6 +406,13 @@ nonisolated enum TranscriptStore {
 
     private static func fileCreationDate(_ url: URL) -> Date? {
         try? url.resourceValues(forKeys: [.creationDateKey]).creationDate
+    }
+
+    /// Drives the summary cache's staleness check: a file rewritten by `save`
+    /// (including through this process) or edited outside it gets a new
+    /// modification date, which is what tells `cachedSummary(for:)` to re-decode.
+    private static func fileModificationDate(_ url: URL) -> Date? {
+        try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
     }
 }
 

--- a/wisprTests/TranscriptLocationTests.swift
+++ b/wisprTests/TranscriptLocationTests.swift
@@ -120,6 +120,40 @@ struct TranscriptLocationTests {
         }
     }
 
+    @Test("Re-activating the already-current folder stays activated")
+    func testReactivatingSameFolderStaysActive() async throws {
+        try await withTemporaryFolder { folder in
+            let bookmark = try TranscriptLocation.makeBookmark(for: folder)
+
+            // Re-picking the same folder in Settings, or `applyStoredFolder` running
+            // again while it is already active, activates the same bookmark twice
+            // in a row. This must not call `startAccessingSecurityScopedResource()`
+            // a second time — doing so would leak one retained access count with
+            // nothing left to close it, since `useDefault()` below balances the
+            // access exactly once.
+            guard case .activated = TranscriptLocation.activate(bookmark: bookmark) else {
+                Issue.record("First activation should succeed")
+                return
+            }
+            guard case .activated = TranscriptLocation.activate(bookmark: bookmark) else {
+                Issue.record("Re-activating the same folder should still succeed")
+                return
+            }
+
+            #expect(TranscriptLocation.isCustom)
+            #expect(
+                TranscriptLocation.current.resolvingSymlinksInPath()
+                    == folder.resolvingSymlinksInPath()
+            )
+
+            // A single stop() balances the two activations above (one real start,
+            // one short-circuited). Dropping to the default folder proves the scope
+            // was left in a consistent state rather than double-opened.
+            TranscriptLocation.useDefault()
+            #expect(TranscriptLocation.isCustom == false)
+        }
+    }
+
     @Test("useDefault() returns to the container after a custom folder")
     func testUseDefaultReleasesCustomFolder() async throws {
         try await withTemporaryFolder { folder in

--- a/wisprTests/TranscriptStoreTests.swift
+++ b/wisprTests/TranscriptStoreTests.swift
@@ -331,6 +331,53 @@ struct TranscriptStoreTests {
         }
     }
 
+    @Test("list() picks up an edit made through save(to:) rather than serving a cached summary")
+    func testListReflectsEditAfterCachedSummary() async throws {
+        try await withCleanup { created in
+            var transcript = makeTranscript(texts: ["avant"])
+            transcript.entries.append(
+                MeetingTranscriptEntry(speaker: .others(speakerIndex: 0), text: "et"))
+            let url = try #require(TranscriptStore.save(transcript))
+            created.append(url)
+
+            // Populate the summary cache with the pre-edit content.
+            let before = try #require(TranscriptStore.list().first { $0.url == url })
+            #expect(before.speakerNames == ["Speaker 1"])
+
+            var edited = try TranscriptStore.load(url)
+            edited.setName("Alice", forSpeakerIndex: 0)
+            try TranscriptStore.save(edited, to: url)
+
+            let after = try #require(TranscriptStore.list().first { $0.url == url })
+            #expect(after.speakerNames == ["Alice"])
+        }
+    }
+
+    @Test("list() picks up a rename rather than serving a summary under the old URL")
+    func testListReflectsRenameAfterCachedSummary() async throws {
+        try await withCleanup { created in
+            let start = TestTranscriptClock.nextStart()
+            var transcript = makeTranscript(start: start)
+            let url = try #require(TranscriptStore.save(transcript))
+            created.append(url)
+
+            // Populate the summary cache under the original (untitled) URL.
+            _ = TranscriptStore.list()
+
+            // The title lives in the file's content; rename() only moves the file
+            // to match. Real callers (MeetingHistoryStore.retitle) always write the
+            // content first, so the test does the same.
+            transcript.setTitle("Sprint review")
+            try TranscriptStore.save(transcript, to: url)
+            let renamed = try TranscriptStore.rename(at: url, startTime: start, title: "Sprint review")
+            created.append(renamed)
+
+            let listed = TranscriptStore.list()
+            #expect(listed.contains { $0.url == renamed && $0.title == "Sprint review" })
+            #expect(!listed.contains { $0.url == url })
+        }
+    }
+
     @Test("list() summarises a saved transcript and sorts newest first")
     func testListSummariesAndOrdering() async throws {
         try await withCleanup { created in


### PR DESCRIPTION
Closes #93. Three commits, one per finding, on top of `main`.

## 1. `Task.detached` breaks the structured-concurrency rule

CLAUDE.md is explicit under Concurrency Patterns: "Structured concurrency only — no `Task.detached`, no GCD, no Combine." Six call sites moved transcript file IO off `@MainActor` this way (`MeetingHistoryStore.swift:71,103,132,176,210`, `MeetingStateManager.swift:192`), which cuts the new task off from the caller's priority, task-local values, and cancellation.

`TranscriptStore` can't literally become an actor as suggested — it's a `nonisolated enum` of `static` members, and actor isolation attaches to instances, not statics. Added `TranscriptIO`, a thin actor wrapping the same static calls, so callers get a real `await` boundary instead of detaching. `TranscriptStore`'s own members stay synchronous: `finalizeForTermination()` runs from `applicationWillTerminate`, which can't `await` at all, so it keeps calling `TranscriptStore` directly rather than going through the actor.

## 2. Listing transcripts fully decodes every file

`summary(for:)` decoded the whole `MeetingTranscript` — every entry — just to pull four fields into `TranscriptSummary`, whose own doc comment says it exists precisely to avoid that cost. `list()` runs on every window appear, after each rename/retitle/delete, on debounced external filesystem changes, and on meeting stop, so it repeats often and its cost scales with total transcribed minutes.

Added an in-memory cache keyed by file URL, tagged with the file's modification date at the time each summary was built. A hit is served when the current mtime still matches; otherwise the file decodes once and the result is cached. Keying on mtime rather than trusting the cache unconditionally means an edit made outside this cache (Finder, another process) is picked up on the next scan.

`save()`/`save(to:)` also push the summary they already have in memory straight into the cache, and `rename()` carries a cached entry to the new URL rather than dropping it (`moveItem` preserves mtime, so the carried entry's staleness check still holds) — both are optimizations layered on an already-correct mtime check, not correctness fixes by themselves. I verified that by removing each in turn and confirming the two new regression tests still passed, which is called out in the commit rather than left implicit.

## 3. Security scope leaks a retain on same-folder re-activation

Confirmed exactly as described: `activate(bookmark:)` always called `startAccessingSecurityScopedResource()`, but `replaceScope` only balanced it with `stop` when the URL changed, so re-picking the same folder leaked one retain per activation.

`activate` now short-circuits when the requested folder is already the current scope, matching the suggested fix. Added a regression test exercising the re-activation path — worth being upfront that it can't observe the leak directly, since the security-scope retain count isn't a public API. I confirmed by hand that the test still passes with the fix reverted, so it proves the code path behaves (still activated, no crash, clean drop to default afterward) rather than proving the counter balances. Flagging this rather than overclaiming what the test covers.

## Testing

- `swift build --target WisprApp`: clean at all three commits.
- `swift test`: 616 tests, all passing except the pre-existing `AudioEngine audio level stream terminates on stop` (fails identically on unmodified `main`, passes in isolation).
- No `Task.detached` remains anywhere in `Sources/WisprApp` (grepped to confirm).
