### PR TITLE
fix(menu): preserve disabled recording action while processing

### DIFF
--- a/Sources/WisprApp/UI/MenuBarController.swift
+++ b/Sources/WisprApp/UI/MenuBarController.swift
@@ -38,7 +38,7 @@ final class MenuBarController {
     private let statusItem: NSStatusItem
 
     /// The dropdown menu displayed when the user clicks the status item.
-    private let menu: NSMenu
+    let menu: NSMenu
 
     /// Reference to the central state manager for wiring actions.
     private let stateManager: StateManager
@@ -93,7 +93,7 @@ final class MenuBarController {
 
     // MARK: - Menu Items (retained for dynamic updates)
 
-    private let recordingMenuItem = NSMenuItem()
+    let recordingMenuItem = NSMenuItem()
     private let meetingMenuItem = NSMenuItem()
     private let stopMeetingMenuItem = NSMenuItem()
     private let languageMenuItem = NSMenuItem()
@@ -175,7 +175,7 @@ final class MenuBarController {
     /// Requirement 5.3: Menu contains Start/Stop Recording, Settings,
     /// Model Management, Language Selection, and Quit.
     private func buildMenu() {
-        Self.disableAutomaticItemEnablement(in: menu)
+        menu.autoenablesItems = false
         menu.removeAllItems()
 
         // Start/Stop Recording
@@ -277,15 +277,10 @@ final class MenuBarController {
         }
     }
 
-    /// Preserves explicit item enablement, such as disabling recording while processing.
-    static func disableAutomaticItemEnablement(in menu: NSMenu) {
-        menu.autoenablesItems = false
-    }
-
     // MARK: - Recording Menu Item
 
     /// Updates the recording menu item title and action based on current state.
-    private func updateRecordingMenuItem() {
+    func updateRecordingMenuItem() {
         let isRecording = stateManager.appState == .recording
         let shortcut = KeyCodeMapping.shared.hotkeyDisplayString(
             keyCode: settingsStore.hotkeyKeyCode,

--- a/Sources/WisprApp/UI/MenuBarController.swift
+++ b/Sources/WisprApp/UI/MenuBarController.swift
@@ -175,6 +175,7 @@ final class MenuBarController {
     /// Requirement 5.3: Menu contains Start/Stop Recording, Settings,
     /// Model Management, Language Selection, and Quit.
     private func buildMenu() {
+        Self.disableAutomaticItemEnablement(in: menu)
         menu.removeAllItems()
 
         // Start/Stop Recording
@@ -274,6 +275,11 @@ final class MenuBarController {
         for item in menu.items where item.action != nil {
             item.target = handler
         }
+    }
+
+    /// Preserves explicit item enablement, such as disabling recording while processing.
+    static func disableAutomaticItemEnablement(in menu: NSMenu) {
+        menu.autoenablesItems = false
     }
 
     // MARK: - Recording Menu Item

--- a/wisprTests/MenuBarControllerTests.swift
+++ b/wisprTests/MenuBarControllerTests.swift
@@ -136,6 +136,25 @@ struct MenuBarControllerIconTests {
 @Suite("MenuBarController Menu Structure Tests")
 struct MenuBarControllerMenuTests {
 
+    @Test("Menu preserves an explicitly disabled recording action")
+    func testMenuPreservesExplicitDisabledState() {
+        let menu = NSMenu()
+        let target = MenuActionTarget()
+        let item = NSMenuItem(
+            title: "Start Recording",
+            action: #selector(MenuActionTarget.toggleRecording(_:)),
+            keyEquivalent: ""
+        )
+        item.target = target
+        menu.addItem(item)
+
+        MenuBarController.disableAutomaticItemEnablement(in: menu)
+        item.isEnabled = false
+        menu.update()
+
+        #expect(!item.isEnabled)
+    }
+
     @Test("Menu contains recording, language, settings, model management, and quit items")
     func testMenuItemCount() {
         let (controller, _, _, _) = createTestController()
@@ -164,6 +183,11 @@ struct MenuBarControllerMenuTests {
         #expect(themeEngine.actionSymbol(.model) == "cpu")
         #expect(themeEngine.actionSymbol(.quit) == "power")
     }
+}
+
+@MainActor
+private final class MenuActionTarget: NSObject {
+    @objc func toggleRecording(_ sender: Any?) {}
 }
 
 // MARK: - Language Display Tests (Requirement 16.7)

--- a/wisprTests/MenuBarControllerTests.swift
+++ b/wisprTests/MenuBarControllerTests.swift
@@ -136,23 +136,19 @@ struct MenuBarControllerIconTests {
 @Suite("MenuBarController Menu Structure Tests")
 struct MenuBarControllerMenuTests {
 
-    @Test("Menu preserves an explicitly disabled recording action")
-    func testMenuPreservesExplicitDisabledState() {
-        let menu = NSMenu()
-        let target = MenuActionTarget()
-        let item = NSMenuItem(
-            title: "Start Recording",
-            action: #selector(MenuActionTarget.toggleRecording(_:)),
-            keyEquivalent: ""
+    @Test("Recording item is disabled while processing")
+    func testRecordingItemDisabledWhileProcessing() {
+        let (controller, stateManager, _, _) = createTestController()
+        stateManager.appState = .processing
+
+        controller.updateRecordingMenuItem()
+        controller.menu.update()
+
+        #expect(
+            !controller.recordingMenuItem.isEnabled,
+            "Recording item should remain disabled while transcription is processing"
         )
-        item.target = target
-        menu.addItem(item)
-
-        MenuBarController.disableAutomaticItemEnablement(in: menu)
-        item.isEnabled = false
-        menu.update()
-
-        #expect(!item.isEnabled)
+        controller.stopObserving()
     }
 
     @Test("Menu contains recording, language, settings, model management, and quit items")
@@ -183,11 +179,6 @@ struct MenuBarControllerMenuTests {
         #expect(themeEngine.actionSymbol(.model) == "cpu")
         #expect(themeEngine.actionSymbol(.quit) == "power")
     }
-}
-
-@MainActor
-private final class MenuActionTarget: NSObject {
-    @objc func toggleRecording(_ sender: Any?) {}
 }
 
 // MARK: - Language Display Tests (Requirement 16.7)


### PR DESCRIPTION
## Summary
- disable AppKit automatic menu-item enablement
- preserve the explicit disabled state of Start/Stop Recording while transcription is processing
- add a focused regression test for the menu behavior

## Testing
- Debug build with Xcode
- Focused AppKit regression check