### PR TITLE
feat(meeting): in-person mode with per-speaker mic diarization

### DIFF
--- a/Sources/WisprApp/Models/MeetingTranscript.swift
+++ b/Sources/WisprApp/Models/MeetingTranscript.swift
@@ -7,6 +7,23 @@
 
 import Foundation
 
+/// How a meeting is captured, which determines the speaker model.
+///
+/// - `online`: the classic remote-meeting shape. Your voice is on the mic and
+///   everyone else arrives through system audio; the mic track is labelled
+///   "You" and only the system track is diarized.
+/// - `inPerson`: everyone is in one room and reaches the same microphone. There
+///   is no privileged "You" — the mic track itself is diarized and every
+///   participant (including the local user) becomes a numbered speaker. System
+///   audio is not captured, so no Screen Recording permission is needed.
+///
+/// Diarization can distinguish up to four participants in person, a fixed limit
+/// of the underlying Sortformer model.
+nonisolated enum MeetingMode: String, Sendable, Codable, CaseIterable {
+    case online
+    case inPerson
+}
+
 /// Identifies the audio source / speaker in a meeting transcript.///
 /// Speaker indices are stored **0-based** internally. The +1 transform to
 /// "Speaker 1", "Speaker 2", etc. happens only inside `displayName`.
@@ -69,6 +86,11 @@ nonisolated struct MeetingTranscript: Sendable, Equatable, Codable {
     var entries: [MeetingTranscriptEntry] = []
     let startTime: Date
 
+    /// How this session was captured. Fixed at `startMeeting()` and never changed
+    /// mid-session, so a transcript never mixes two labelling schemes. Archived
+    /// transcripts written before this field existed decode as `.online`.
+    var mode: MeetingMode = .online
+
     /// User-assigned title for the session, or `nil` to fall back to its date.
     ///
     /// A meeting's date is a poor handle once there are more than a handful of
@@ -91,7 +113,7 @@ nonisolated struct MeetingTranscript: Sendable, Equatable, Codable {
     // MARK: - Codable
 
     private enum CodingKeys: String, CodingKey {
-        case entries, startTime, speakerNames, title
+        case entries, startTime, speakerNames, title, mode
     }
 
     /// Decodes a transcript, tolerating files written before `speakerNames` and
@@ -109,6 +131,7 @@ nonisolated struct MeetingTranscript: Sendable, Equatable, Codable {
         self.speakerNames =
             try container.decodeIfPresent([String: String].self, forKey: .speakerNames) ?? [:]
         self.title = try container.decodeIfPresent(String.self, forKey: .title)
+        self.mode = try container.decodeIfPresent(MeetingMode.self, forKey: .mode) ?? .online
     }
 
     // MARK: - Title

--- a/Sources/WisprApp/Services/MeetingAudioEngine.swift
+++ b/Sources/WisprApp/Services/MeetingAudioEngine.swift
@@ -26,6 +26,16 @@ struct SystemAudioChunk: Sendable {
     let startTime: TimeInterval
 }
 
+/// A timestamped audio chunk from the microphone capture path.
+///
+/// `startTime` is seconds elapsed since capture began (cumulative sample count /
+/// sampleRate), mirroring `SystemAudioChunk`. In-person meetings diarize the mic
+/// track, and `MeetingDiarizer` needs a timeline to attribute chunks to speakers.
+struct MicAudioChunk: Sendable {
+    let samples: [Float]
+    let startTime: TimeInterval
+}
+
 /// Actor responsible for capturing both microphone and system audio simultaneously.
 ///
 /// Uses `AVAudioEngine` for microphone input and `SCStream` (ScreenCaptureKit)
@@ -42,11 +52,13 @@ actor MeetingAudioEngine {
     private var systemStreamOutput: SystemAudioOutputHandler?
 
     private var micBuffer: [Float] = []
+    private var micSamplesTotal: Int = 0
+    private var micChunkStartSamples: Int = 0
     private var systemBuffer: [Float] = []
     private var systemSamplesTotal: Int = 0
     private var systemChunkStartSamples: Int = 0
 
-    private var micContinuation: AsyncStream<[Float]>.Continuation?
+    private var micContinuation: AsyncStream<MicAudioChunk>.Continuation?
     private var systemContinuation: AsyncStream<SystemAudioChunk>.Continuation?
     private var micLevelContinuation: AsyncStream<Float>.Continuation?
     private var systemLevelContinuation: AsyncStream<Float>.Continuation?
@@ -61,15 +73,30 @@ actor MeetingAudioEngine {
     /// Whether system audio capture is active (may be false if permission denied).
     private var hasSystemAudio = false
 
+    /// Capture mode for the active session. In-person capture is mic-only and
+    /// diarizes the mic track, so it uses the shorter chunk size below.
+    private var captureMode: MeetingMode = .online
+
     /// The audio chunk streams created at capture start.
-    private var _micAudioStream: AsyncStream<[Float]>?
+    private var _micAudioStream: AsyncStream<MicAudioChunk>?
     private var _systemAudioStream: AsyncStream<SystemAudioChunk>?
 
-    /// The chunk size in samples before yielding to the transcription stream.
+    /// Online mic chunk size in samples before yielding to transcription.
     /// ~5 seconds of audio at 16kHz = 80,000 samples.
-    private let chunkSize = 80_000
+    private let onlineMicChunkSize = 80_000
 
-    /// System-audio chunk size. Shorter than the mic chunk (~3s) so each
+    /// In-person mic chunk size (~3s). Shorter than the online mic chunk so each
+    /// diarized transcript entry spans less time, reducing how often a single
+    /// entry flattens a speaker change into one label — the same rationale as the
+    /// system-audio chunk in online mode.
+    private let inPersonMicChunkSize = 48_000
+
+    /// Active mic chunk size, chosen by `captureMode` at `startCapture()`.
+    private var micChunkSize: Int {
+        captureMode == .inPerson ? inPersonMicChunkSize : onlineMicChunkSize
+    }
+
+    /// System-audio chunk size. Shorter than the online mic chunk (~3s) so each
     /// transcript entry spans less time, reducing how often a single entry
     /// flattens a speaker change into one diarization label.
     private let systemChunkSize = 48_000
@@ -84,9 +111,14 @@ actor MeetingAudioEngine {
     /// System audio capture may silently fail if Screen Recording permission
     /// is not granted — in that case, only mic capture is active.
     ///
+    /// - Parameter mode: `.online` captures mic + system audio (system audio may
+    ///   still fall back to mic-only if permission is denied). `.inPerson`
+    ///   captures the microphone only and never touches ScreenCaptureKit, so it
+    ///   avoids the Screen Recording permission prompt entirely.
     /// - Returns: A tuple of (micLevelStream, systemLevelStream) for UI visualization.
+    ///   In `.inPerson` mode the system level stream is silent (finishes immediately).
     /// - Throws: If microphone capture fails to start.
-    func startCapture() async throws -> (
+    func startCapture(mode: MeetingMode = .online) async throws -> (
         micLevels: AsyncStream<Float>, systemLevels: AsyncStream<Float>
     ) {
         guard !isCapturing else {
@@ -94,12 +126,15 @@ actor MeetingAudioEngine {
         }
 
         isCapturing = true
+        captureMode = mode
         micBuffer.removeAll()
+        micSamplesTotal = 0
+        micChunkStartSamples = 0
         systemBuffer.removeAll()
 
         // Create audio chunk streams upfront so continuations are ready
         // before the taps start producing data.
-        let (micStream, micCont) = AsyncStream.makeStream(of: [Float].self)
+        let (micStream, micCont) = AsyncStream.makeStream(of: MicAudioChunk.self)
         _micAudioStream = micStream
         micContinuation = micCont
 
@@ -108,6 +143,17 @@ actor MeetingAudioEngine {
         systemContinuation = sysCont
 
         let micLevels = startMicCapture()
+
+        // In-person meetings are mic-only: everyone is in the room and reaches the
+        // microphone, so there is no remote audio to capture and no reason to ask
+        // for Screen Recording permission.
+        guard mode == .online else {
+            hasSystemAudio = false
+            let (silentStream, silentCont) = AsyncStream.makeStream(of: Float.self)
+            silentCont.finish()
+            Log.audioEngine.debug("MeetingAudioEngine — in-person mode: mic-only capture")
+            return (micLevels, silentStream)
+        }
 
         // Attempt system audio capture — fall back to mic-only on failure
         let systemLevels: AsyncStream<Float>
@@ -140,9 +186,9 @@ actor MeetingAudioEngine {
     }
 
     /// Returns the mic audio chunk stream created during `startCapture()`.
-    var micAudioStream: AsyncStream<[Float]> {
+    var micAudioStream: AsyncStream<MicAudioChunk> {
         if let stream = _micAudioStream { return stream }
-        let (stream, cont) = AsyncStream.makeStream(of: [Float].self)
+        let (stream, cont) = AsyncStream.makeStream(of: MicAudioChunk.self)
         cont.finish()
         return stream
     }
@@ -158,7 +204,8 @@ actor MeetingAudioEngine {
     /// Flushes any remaining buffered audio as final chunks.
     func flushBuffers() {
         if !micBuffer.isEmpty {
-            micContinuation?.yield(micBuffer)
+            let startTime = Double(micChunkStartSamples) / Double(Self.sampleRate)
+            micContinuation?.yield(MicAudioChunk(samples: micBuffer, startTime: startTime))
             micBuffer.removeAll()
         }
         if !systemBuffer.isEmpty {
@@ -269,13 +316,18 @@ actor MeetingAudioEngine {
         let normalizedLevel = min(max(rms * 5.0, 0.0), 1.0)
         micLevelContinuation?.yield(normalizedLevel)
 
+        micSamplesTotal += samples.count
         micBuffer.append(contentsOf: samples)
+        let chunkSize = micChunkSize
         if micBuffer.count >= chunkSize {
             let chunk = Array(micBuffer.prefix(chunkSize))
             micBuffer.removeFirst(min(chunkSize, micBuffer.count))
+            let startTime = Double(micChunkStartSamples) / Double(Self.sampleRate)
+            micChunkStartSamples = micSamplesTotal - micBuffer.count
             Log.audioEngine.debug(
-                "MeetingAudioEngine — yielding mic chunk of \(chunk.count) samples")
-            micContinuation?.yield(chunk)
+                "MeetingAudioEngine — yielding mic chunk of \(chunk.count) samples at t=\(String(format: "%.2f", startTime))s"
+            )
+            micContinuation?.yield(MicAudioChunk(samples: chunk, startTime: startTime))
         }
     }
 
@@ -289,6 +341,8 @@ actor MeetingAudioEngine {
         engine.inputNode.removeTap(onBus: 0)
         micEngine = nil
         micBuffer.removeAll()
+        micSamplesTotal = 0
+        micChunkStartSamples = 0
         micContinuation?.finish()
         micContinuation = nil
         micLevelContinuation?.finish()

--- a/Sources/WisprApp/Services/MeetingStateManager.swift
+++ b/Sources/WisprApp/Services/MeetingStateManager.swift
@@ -53,10 +53,13 @@ final class MeetingStateManager {
     /// Always 0 in `.inPerson` mode, which does not capture system audio.
     var systemLevel: Float = 0
 
-    /// Capture mode for the next (or current) meeting. Bound to the header
-    /// toggle and seeded from the last remembered choice. Editable only while
-    /// idle — the header disables the toggle during recording so a transcript
-    /// never mixes two labelling schemes.
+    /// Capture mode for the **next** meeting. Bound to the header toggle and
+    /// seeded from the last remembered choice.
+    ///
+    /// Once a meeting starts this is copied to `transcript.mode`, which is the
+    /// canonical mode for the running session — every mode-dependent decision
+    /// (labelling, diarization, echo suppression) reads that frozen value rather
+    /// than this binding, so a transcript can never mix two labelling schemes.
     ///
     /// Selecting in-person turns on diarization automatically: it is what
     /// separates the people in the room, and without it the whole room collapses
@@ -186,7 +189,9 @@ final class MeetingStateManager {
     /// collapses into a single speaker, which defeats the mode. Online mode only
     /// warms it when the user opted into diarization.
     private func warmUpDiarizerIfEnabled() async {
-        let wantsDiarization = mode == .inPerson || settingsStore.meetingDiarizationEnabled
+        // `transcript.mode` is the frozen session mode, set once at startMeeting().
+        let wantsDiarization =
+            transcript.mode == .inPerson || settingsStore.meetingDiarizationEnabled
         guard wantsDiarization, let diarizer = meetingDiarizer else {
             return
         }
@@ -301,10 +306,31 @@ final class MeetingStateManager {
 
     // MARK: - Transcription
 
+    /// The transcript label for a microphone chunk.
+    ///
+    /// Online, the mic is always the local user, so it is labelled `.you` and the
+    /// diarized index (if any) is ignored. In person the mic carries the whole
+    /// room and there is no privileged "You": every chunk becomes a numbered
+    /// participant, falling back to `.others(nil)` — rendered "Others" — while
+    /// the diarizer is cold or switched off.
+    ///
+    /// Extracted from `transcribeMicAudio()` so this decision is testable without
+    /// microphone hardware.
+    static func micSpeaker(mode: MeetingMode, diarizedIndex: Int?) -> MeetingSpeaker {
+        switch mode {
+        case .online:
+            return .you
+        case .inPerson:
+            return .others(speakerIndex: diarizedIndex)
+        }
+    }
+
     private func transcribeMicAudio() async {
         let audioStream = await meetingAudioEngine.micAudioStream
         let language = settingsStore.languageMode
-        let isInPerson = mode == .inPerson
+        // The frozen session mode, not the live header binding: a transcript must
+        // never mix two labelling schemes even if the toggle were ever unlocked.
+        let isInPerson = transcript.mode == .inPerson
 
         for await chunk in audioStream {
             guard !Task.isCancelled else { break }
@@ -325,24 +351,24 @@ final class MeetingStateManager {
                 let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !text.isEmpty else { continue }
 
-                let speaker: MeetingSpeaker
-                if isInPerson {
-                    // Resolve the dominant speaker over the chunk's time window.
-                    // nil (cold-start or diarization off) renders as plain "Others".
-                    var speakerIndex: Int?
-                    if let diarizer {
-                        let chunkEnd =
-                            chunk.startTime
-                            + Double(chunk.samples.count) / Double(MeetingAudioEngine.sampleRate)
-                        speakerIndex = await diarizer.dominantSpeaker(
-                            in: chunk.startTime...chunkEnd)
-                    }
-                    speaker = .others(speakerIndex: speakerIndex)
-                } else {
-                    speaker = .you
+                // Resolve the dominant speaker over the chunk's time window.
+                // nil (cold-start or diarization off) renders as plain "Others".
+                var speakerIndex: Int?
+                if let diarizer {
+                    let chunkEnd =
+                        chunk.startTime
+                        + Double(chunk.samples.count) / Double(MeetingAudioEngine.sampleRate)
+                    speakerIndex = await diarizer.dominantSpeaker(
+                        in: chunk.startTime...chunkEnd)
                 }
 
-                record(MeetingTranscriptEntry(speaker: speaker, text: text))
+                record(
+                    MeetingTranscriptEntry(
+                        speaker: Self.micSpeaker(
+                            mode: transcript.mode, diarizedIndex: speakerIndex),
+                        text: text
+                    )
+                )
             } catch {
                 if case WisprError.emptyTranscription = error { continue }
                 Log.stateManager.warning(
@@ -403,8 +429,10 @@ final class MeetingStateManager {
     /// In-person mode bypasses echo suppression entirely: there is no remote
     /// audio, so the mechanism can only produce false positives (two people in a
     /// room saying similar short phrases).
-    private func record(_ entry: MeetingTranscriptEntry) {
-        guard mode == .online, settingsStore.meetingEchoSuppressionEnabled else {
+    /// Internal rather than private so tests can drive it directly: the bypass
+    /// depends on session state that is otherwise only reachable with live audio.
+    func record(_ entry: MeetingTranscriptEntry) {
+        guard transcript.mode == .online, settingsStore.meetingEchoSuppressionEnabled else {
             transcript.entries.append(entry)
             return
         }

--- a/Sources/WisprApp/Services/MeetingStateManager.swift
+++ b/Sources/WisprApp/Services/MeetingStateManager.swift
@@ -23,10 +23,11 @@ enum MeetingState: Sendable, Equatable {
 /// Orchestrates microphone capture, runs continuous chunked transcription,
 /// and assembles a timestamped transcript.
 ///
-/// Note: Currently captures microphone only. System audio capture (for remote
-/// meeting participants) requires Screen Recording permission which is
-/// incompatible with App Sandbox. Speaker labels default to "You" for all
-/// entries until system audio support is added.
+/// Two capture shapes are supported (see `MeetingMode`):
+/// - `.online`: mic ("You") plus diarized system audio ("Others" / per-speaker).
+/// - `.inPerson`: mic only, with the mic track itself diarized so each person in
+///   the room becomes a numbered speaker and there is no privileged "You". No
+///   system audio and no Screen Recording permission is involved.
 @MainActor
 @Observable
 final class MeetingStateManager {
@@ -49,9 +50,25 @@ final class MeetingStateManager {
     var micLevel: Float = 0
 
     /// Audio level from system audio (0.0–1.0) for UI visualization.
-    /// Currently always 0 — system audio capture requires Screen Recording
-    /// permission which is incompatible with App Sandbox.
+    /// Always 0 in `.inPerson` mode, which does not capture system audio.
     var systemLevel: Float = 0
+
+    /// Capture mode for the next (or current) meeting. Bound to the header
+    /// toggle and seeded from the last remembered choice. Editable only while
+    /// idle — the header disables the toggle during recording so a transcript
+    /// never mixes two labelling schemes.
+    ///
+    /// Selecting in-person turns on diarization automatically: it is what
+    /// separates the people in the room, and without it the whole room collapses
+    /// into a single speaker. Switching back to online leaves the setting as the
+    /// user last had it — online diarization stays opt-in.
+    var mode: MeetingMode = .online {
+        didSet {
+            if mode == .inPerson {
+                settingsStore.meetingDiarizationEnabled = true
+            }
+        }
+    }
 
     /// Error message, if any.
     var errorMessage: String?
@@ -68,9 +85,11 @@ final class MeetingStateManager {
     private let transcriptionEngine: any TranscriptionEngine
     private let settingsStore: SettingsStore
 
-    /// Optional speaker-diarization engine for the system-audio ("Others") track.
-    /// `nil` disables diarization entirely (e.g. in tests). When present, it is
-    /// only warmed up if `settingsStore.meetingDiarizationEnabled` is true.
+    /// Optional speaker-diarization engine. In online mode it diarizes the
+    /// system-audio ("Others") track; in in-person mode it diarizes the mic track.
+    /// `nil` disables diarization entirely (e.g. in tests). It is warmed up when
+    /// `settingsStore.meetingDiarizationEnabled` is true, or unconditionally in
+    /// in-person mode (where diarization is what makes the mode meaningful).
     private let meetingDiarizer: MeetingDiarizer?
 
     /// Whether diarization is active for the current session (set at startMeeting).
@@ -103,6 +122,7 @@ final class MeetingStateManager {
         self.transcriptionEngine = transcriptionEngine
         self.settingsStore = settingsStore
         self.meetingDiarizer = meetingDiarizer
+        self.mode = settingsStore.meetingInPersonMode ? .inPerson : .online
     }
 
     // MARK: - Meeting Lifecycle
@@ -115,12 +135,24 @@ final class MeetingStateManager {
 
         Log.stateManager.debug("MeetingStateManager — starting meeting")
 
+        // Capture the mode for this session and remember the choice for next time.
+        let sessionMode = mode
+        settingsStore.meetingInPersonMode = (sessionMode == .inPerson)
+        // In-person meetings rely on diarization to tell participants apart, so
+        // ensure it is on even when the mode was restored from a prior session
+        // rather than toggled this launch.
+        if sessionMode == .inPerson {
+            settingsStore.meetingDiarizationEnabled = true
+        }
+
         transcript = MeetingTranscript()
+        transcript.mode = sessionMode
         errorMessage = nil
         diarizationActive = false
 
         do {
-            let (micLevels, systemLevels) = try await meetingAudioEngine.startCapture()
+            let (micLevels, systemLevels) = try await meetingAudioEngine.startCapture(
+                mode: sessionMode)
 
             // Flip to recording immediately so the UI is responsive. The diarizer
             // (if enabled) warms up concurrently below — chunks that arrive before
@@ -147,10 +179,15 @@ final class MeetingStateManager {
     }
 
     /// Warms up the diarizer in the background when enabled, so it's ready for
-    /// upcoming system-audio chunks without blocking the recording start.
-    /// On failure, degrades gracefully to source-based "Others" labels.
+    /// upcoming chunks without blocking the recording start. On failure, degrades
+    /// gracefully to plain "Others" labels.
+    ///
+    /// In-person mode always warms the diarizer: without it the whole room
+    /// collapses into a single speaker, which defeats the mode. Online mode only
+    /// warms it when the user opted into diarization.
     private func warmUpDiarizerIfEnabled() async {
-        guard settingsStore.meetingDiarizationEnabled, let diarizer = meetingDiarizer else {
+        let wantsDiarization = mode == .inPerson || settingsStore.meetingDiarizationEnabled
+        guard wantsDiarization, let diarizer = meetingDiarizer else {
             return
         }
         do {
@@ -267,17 +304,45 @@ final class MeetingStateManager {
     private func transcribeMicAudio() async {
         let audioStream = await meetingAudioEngine.micAudioStream
         let language = settingsStore.languageMode
+        let isInPerson = mode == .inPerson
 
         for await chunk in audioStream {
             guard !Task.isCancelled else { break }
-            guard chunk.count >= 8000 else { continue }
+            guard chunk.samples.count >= 8000 else { continue }
+
+            // In person, the mic carries the whole room, so it is the track we
+            // diarize. Re-check per chunk: the diarizer may finish warming up
+            // mid-meeting. Online, the mic is always "You" and never diarized.
+            let diarizer = (isInPerson && diarizationActive) ? meetingDiarizer : nil
+
+            // Feed the chunk to the diarizer before transcribing so its timeline
+            // covers this window by the time we query the dominant speaker.
+            await diarizer?.ingest(chunk.samples, at: chunk.startTime)
 
             do {
-                let result = try await transcriptionEngine.transcribe(chunk, language: language)
+                let result = try await transcriptionEngine.transcribe(
+                    chunk.samples, language: language)
                 let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !text.isEmpty else { continue }
 
-                record(MeetingTranscriptEntry(speaker: .you, text: text))
+                let speaker: MeetingSpeaker
+                if isInPerson {
+                    // Resolve the dominant speaker over the chunk's time window.
+                    // nil (cold-start or diarization off) renders as plain "Others".
+                    var speakerIndex: Int?
+                    if let diarizer {
+                        let chunkEnd =
+                            chunk.startTime
+                            + Double(chunk.samples.count) / Double(MeetingAudioEngine.sampleRate)
+                        speakerIndex = await diarizer.dominantSpeaker(
+                            in: chunk.startTime...chunkEnd)
+                    }
+                    speaker = .others(speakerIndex: speakerIndex)
+                } else {
+                    speaker = .you
+                }
+
+                record(MeetingTranscriptEntry(speaker: speaker, text: text))
             } catch {
                 if case WisprError.emptyTranscription = error { continue }
                 Log.stateManager.warning(
@@ -334,8 +399,12 @@ final class MeetingStateManager {
     /// setting is enabled. Echo suppression drops mic ("You") transcriptions that
     /// duplicate a recent remote ("Others") transcription — the result of remote
     /// speech leaking from the speakers into the mic (issue #65).
+    ///
+    /// In-person mode bypasses echo suppression entirely: there is no remote
+    /// audio, so the mechanism can only produce false positives (two people in a
+    /// room saying similar short phrases).
     private func record(_ entry: MeetingTranscriptEntry) {
-        guard settingsStore.meetingEchoSuppressionEnabled else {
+        guard mode == .online, settingsStore.meetingEchoSuppressionEnabled else {
             transcript.entries.append(entry)
             return
         }

--- a/Sources/WisprApp/Services/SettingsStore.swift
+++ b/Sources/WisprApp/Services/SettingsStore.swift
@@ -116,6 +116,16 @@ final class SettingsStore {
         }
     }
 
+    /// Remembers the last meeting capture mode chosen in the meeting window's
+    /// header toggle. `true` means the next meeting defaults to in-person
+    /// (mic-only, diarized, no privileged "You"). Defaults to false (online).
+    var meetingInPersonMode: Bool {
+        didSet {
+            guard !isLoading else { return }
+            defaults.set(meetingInPersonMode, forKey: Keys.meetingInPersonMode)
+        }
+    }
+
     /// When true, plays short audio cues on recording start/stop.
     var soundFeedbackEnabled: Bool {
         didSet {
@@ -221,6 +231,7 @@ final class SettingsStore {
         static let handsFreeMode = "handsFreeMode"
         static let meetingDiarizationEnabled = "meetingDiarizationEnabled"
         static let meetingEchoSuppressionEnabled = "meetingEchoSuppressionEnabled"
+        static let meetingInPersonMode = "meetingInPersonMode"
         static let soundFeedbackEnabled = "soundFeedbackEnabled"
         static let meetingDetectionEnabled = "meetingDetectionEnabled"
         static let transcriptsFolderBookmark = "transcriptsFolderBookmark"
@@ -249,6 +260,7 @@ final class SettingsStore {
         static let handsFreeMode: Bool = false
         static let meetingDiarizationEnabled: Bool = false
         static let meetingEchoSuppressionEnabled: Bool = true
+        static let meetingInPersonMode: Bool = false
         static let soundFeedbackEnabled: Bool = false
         static let meetingDetectionEnabled: Bool = false
         static let transcriptsFolderBookmark: Data? = nil
@@ -281,6 +293,7 @@ final class SettingsStore {
         self.handsFreeMode = Defaults.handsFreeMode
         self.meetingDiarizationEnabled = Defaults.meetingDiarizationEnabled
         self.meetingEchoSuppressionEnabled = Defaults.meetingEchoSuppressionEnabled
+        self.meetingInPersonMode = Defaults.meetingInPersonMode
         self.soundFeedbackEnabled = Defaults.soundFeedbackEnabled
         self.meetingDetectionEnabled = Defaults.meetingDetectionEnabled
         self.transcriptsFolderBookmark = Defaults.transcriptsFolderBookmark
@@ -311,6 +324,7 @@ final class SettingsStore {
         handsFreeMode = Defaults.handsFreeMode
         meetingDiarizationEnabled = Defaults.meetingDiarizationEnabled
         meetingEchoSuppressionEnabled = Defaults.meetingEchoSuppressionEnabled
+        meetingInPersonMode = Defaults.meetingInPersonMode
         soundFeedbackEnabled = Defaults.soundFeedbackEnabled
         meetingDetectionEnabled = Defaults.meetingDetectionEnabled
         // Files already written to a custom folder are left where they are; only
@@ -343,6 +357,7 @@ final class SettingsStore {
         defaults.set(handsFreeMode, forKey: Keys.handsFreeMode)
         defaults.set(meetingDiarizationEnabled, forKey: Keys.meetingDiarizationEnabled)
         defaults.set(meetingEchoSuppressionEnabled, forKey: Keys.meetingEchoSuppressionEnabled)
+        defaults.set(meetingInPersonMode, forKey: Keys.meetingInPersonMode)
         defaults.set(soundFeedbackEnabled, forKey: Keys.soundFeedbackEnabled)
         defaults.set(meetingDetectionEnabled, forKey: Keys.meetingDetectionEnabled)
         defaults.set(autoSuffixEnabled, forKey: Keys.autoSuffixEnabled)
@@ -418,6 +433,10 @@ final class SettingsStore {
         if defaults.object(forKey: Keys.meetingEchoSuppressionEnabled) != nil {
             self.meetingEchoSuppressionEnabled = defaults.bool(
                 forKey: Keys.meetingEchoSuppressionEnabled)
+        }
+
+        if defaults.object(forKey: Keys.meetingInPersonMode) != nil {
+            self.meetingInPersonMode = defaults.bool(forKey: Keys.meetingInPersonMode)
         }
 
         if defaults.object(forKey: Keys.soundFeedbackEnabled) != nil {

--- a/Sources/WisprApp/UI/Meeting/MeetingTranscriptView.swift
+++ b/Sources/WisprApp/UI/Meeting/MeetingTranscriptView.swift
@@ -26,6 +26,9 @@ struct MeetingTranscriptView: View {
     /// can increase the AppKit window by exactly the same amount.
     static let historySidebarWidth: CGFloat = 210
     static let historyWidthIncrement = historySidebarWidth + 1  // Divider
+    /// Smallest usable height, shared with `MeetingWindowPanel` so the window's
+    /// floor and the content's declared minimum cannot drift apart.
+    static let minimumHeight: CGFloat = 420
 
     @Environment(MeetingStateManager.self) private var meetingState: MeetingStateManager
     @Environment(MeetingHistoryStore.self) private var history: MeetingHistoryStore
@@ -76,7 +79,7 @@ struct MeetingTranscriptView: View {
             minWidth: showHistory
                 ? Self.compactMinimumWidth + Self.historyWidthIncrement
                 : Self.compactMinimumWidth,
-            minHeight: 420
+            minHeight: Self.minimumHeight
         )
         .onChange(of: showHistory) { _, visible in
             onHistoryVisibilityChanged?(visible)

--- a/Sources/WisprApp/UI/Meeting/MeetingTranscriptView.swift
+++ b/Sources/WisprApp/UI/Meeting/MeetingTranscriptView.swift
@@ -20,9 +20,19 @@ import os
 /// `MeetingStateManager.transcript`: starting a meeting resets the live
 /// transcript, which would otherwise wipe an archived one the user was reading.
 struct MeetingTranscriptView: View {
+    /// The smallest useful width for the transcript and its one-line controls.
+    static let compactMinimumWidth: CGFloat = 370
+    /// Stable sidebar width, shared with `MeetingWindowPanel` so opening history
+    /// can increase the AppKit window by exactly the same amount.
+    static let historySidebarWidth: CGFloat = 210
+    static let historyWidthIncrement = historySidebarWidth + 1  // Divider
+
     @Environment(MeetingStateManager.self) private var meetingState: MeetingStateManager
     @Environment(MeetingHistoryStore.self) private var history: MeetingHistoryStore
     @Environment(UIThemeEngine.self) private var theme: UIThemeEngine
+
+    /// Lets the AppKit-owned panel resize when the sidebar changes visibility.
+    let onHistoryVisibilityChanged: ((Bool) -> Void)?
 
     @State private var isExporting = false
     /// Speaker index whose name is being edited, and the in-flight text.
@@ -31,11 +41,9 @@ struct MeetingTranscriptView: View {
     /// Drives keyboard focus into the rename field the moment it appears, so the
     /// user can type immediately instead of having to click the field first.
     @FocusState private var speakerFieldFocused: Bool
-    /// Whether the history column is shown. Plain view state rather than a
-    /// `NavigationSplitView` column binding: this window is a utility `NSPanel`
-    /// with no `NSToolbar`, so the split view's own chrome cannot render into a
-    /// title bar and lands in the content area instead.
-    @State private var showHistory = true
+    /// History starts closed for a compact meeting window. It remains view state
+    /// for the lifetime of the retained panel, rather than resetting on reopen.
+    @State private var showHistory = false
 
     // MARK: - Displayed transcript
 
@@ -54,16 +62,25 @@ struct MeetingTranscriptView: View {
         HStack(spacing: 0) {
             if showHistory {
                 MeetingHistorySidebar()
-                    .frame(minWidth: 190, idealWidth: 210, maxWidth: 280)
+                    .frame(width: Self.historySidebarWidth)
                 Divider()
             }
 
+            // The header needs enough room for the Start button and the capture
+            // mode picker to remain on one line. When history is open, the panel
+            // grows by exactly its fixed sidebar width rather than squeezing here.
             detailPane
+                .frame(minWidth: Self.compactMinimumWidth)
         }
-        // Sized for sidebar + transcript: the rows spend ~154pt on the timestamp
-        // and speaker columns before any text, so a narrower window leaves the
-        // transcript unreadable.
-        .frame(minWidth: 620, minHeight: 420)
+        .frame(
+            minWidth: showHistory
+                ? Self.compactMinimumWidth + Self.historyWidthIncrement
+                : Self.compactMinimumWidth,
+            minHeight: 420
+        )
+        .onChange(of: showHistory) { _, visible in
+            onHistoryVisibilityChanged?(visible)
+        }
         .fileExporter(
             isPresented: $isExporting,
             document: TranscriptDocument(text: transcript.asPlainText()),
@@ -153,32 +170,7 @@ struct MeetingTranscriptView: View {
 
             // Start/Stop sits in the header rather than the transcript body, so
             // it stays reachable while an archived session is on screen.
-            Button {
-                Task { await meetingState.toggleMeeting() }
-            } label: {
-                HStack(spacing: 6) {
-                    Image(
-                        systemName: meetingState.meetingState == .recording
-                            ? SFSymbols.stopFill
-                            : SFSymbols.recordingMicrophone
-                    )
-                    .font(.body)
-
-                    Text(meetingState.meetingState == .recording ? "Stop" : "Start Meeting")
-                        .font(.callout.weight(.medium))
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-                .background(
-                    meetingState.meetingState == .recording
-                        ? Color.red.opacity(0.15)
-                        : theme.accentColor.opacity(0.15)
-                )
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(
-                meetingState.meetingState == .recording ? "Stop meeting" : "Start meeting")
+            recordButton
 
             if isArchived {
                 archivedHeaderContent
@@ -190,15 +182,82 @@ struct MeetingTranscriptView: View {
         .padding(.vertical, 10)
     }
 
+    /// Start/Stop control. The label never wraps: when the header is too narrow
+    /// for "Start Meeting"/"Stop" beside the icon, it collapses to the icon alone
+    /// rather than stacking the text vertically.
+    private var recordButton: some View {
+        let isRecording = meetingState.meetingState == .recording
+        let icon = isRecording ? SFSymbols.stopFill : SFSymbols.recordingMicrophone
+        let title = isRecording ? "Stop" : "Start Meeting"
+        let tint = isRecording ? Color.red : theme.accentColor
+
+        return Button {
+            Task { await meetingState.toggleMeeting() }
+        } label: {
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 6) {
+                    Image(systemName: icon).font(.body)
+                    Text(title)
+                        .font(.callout.weight(.medium))
+                        .lineLimit(1)
+                        .fixedSize()
+                }
+                // Fallback for a narrow header: the icon carries the action.
+                Image(systemName: icon).font(.body)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(tint.opacity(0.15))
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .help(isRecording ? "Stop meeting" : "Start meeting")
+        .accessibilityLabel(isRecording ? "Stop meeting" : "Start meeting")
+    }
+
     @ViewBuilder
     private var liveHeaderContent: some View {
+        @Bindable var meetingState = meetingState
+        let isRecording = meetingState.meetingState == .recording
+
+        // Capture mode. Locked while recording so a transcript never mixes two
+        // labelling schemes.
+        Picker("Meeting mode", selection: $meetingState.mode) {
+            Text("Online").tag(MeetingMode.online)
+            Text("In person").tag(MeetingMode.inPerson)
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .fixedSize()
+        .disabled(isRecording)
+        .help(
+            "Online captures your mic plus system audio. In person diarizes the mic for up to four people in the room."
+        )
+        .accessibilityHint(
+            "Choose a remote or an in-person meeting recorded on the microphone. Locked while recording."
+        )
+
         Spacer()
 
-        if meetingState.meetingState == .recording {
-            HStack(spacing: 8) {
-                audioLevelIndicator(label: "You", level: meetingState.micLevel, color: .blue)
-                audioLevelIndicator(
-                    label: "Others", level: meetingState.systemLevel, color: .green)
+        if isRecording {
+            // The level indicators are the first thing to go when the header runs
+            // out of room: hide them wholesale rather than let their labels wrap.
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) {
+                    if meetingState.mode == .inPerson {
+                        // In person the mic carries the whole room; it is the only
+                        // meaningful level.
+                        audioLevelIndicator(
+                            label: "Room", level: meetingState.micLevel, color: .green)
+                    } else {
+                        audioLevelIndicator(
+                            label: "You", level: meetingState.micLevel, color: .blue)
+                        audioLevelIndicator(
+                            label: "Others", level: meetingState.systemLevel, color: .green)
+                    }
+                }
+                // Fallback: nothing, so the timer keeps its place at narrow widths.
+                Color.clear.frame(width: 0, height: 0)
             }
 
             Text(meetingState.elapsedTime)
@@ -246,6 +305,8 @@ struct MeetingTranscriptView: View {
             Text(label)
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .fixedSize()
         }
     }
 
@@ -282,7 +343,9 @@ struct MeetingTranscriptView: View {
                     .foregroundStyle(.secondary)
 
                 Text(
-                    "Press Start to capture your microphone and system audio.\nSpeakers are separated automatically."
+                    meetingState.mode == .inPerson
+                        ? "Press Start to record everyone in the room on your microphone.\nUp to four speakers are separated automatically."
+                        : "Press Start to capture your microphone and system audio.\nSpeakers are separated automatically."
                 )
                 .font(.callout)
                 .foregroundStyle(.tertiary)

--- a/Sources/WisprApp/UI/Meeting/MeetingWindowPanel.swift
+++ b/Sources/WisprApp/UI/Meeting/MeetingWindowPanel.swift
@@ -42,7 +42,6 @@ final class MeetingWindowPanel: NSObject, NSWindowDelegate {
 
     /// Key under which AppKit autosaves this window's frame.
     private static let frameAutosaveName = "MeetingTranscriptionWindow"
-    private static let minimumHeight: CGFloat = 420
     private static let widthTolerance: CGFloat = 0.5
 
     /// Whether AppKit has a stored frame for this window.
@@ -141,7 +140,7 @@ final class MeetingWindowPanel: NSObject, NSWindowDelegate {
         panel.contentView = hostingView
         panel.minSize = NSSize(
             width: MeetingTranscriptView.compactMinimumWidth,
-            height: Self.minimumHeight
+            height: MeetingTranscriptView.minimumHeight
         )
         panel.isReleasedWhenClosed = false
         panel.delegate = self

--- a/Sources/WisprApp/UI/Meeting/MeetingWindowPanel.swift
+++ b/Sources/WisprApp/UI/Meeting/MeetingWindowPanel.swift
@@ -19,6 +19,14 @@ final class MeetingWindowPanel: NSObject, NSWindowDelegate {
     // MARK: - Properties
 
     private var panel: NSPanel?
+    /// The full frame width before history was opened, retained so a close can
+    /// restore precisely the compact width rather than a hard-coded size.
+    private var compactFrameWidth: CGFloat?
+    /// The full frame width produced by the most recent programmatic expansion.
+    /// If the user resizes while history is open, the close path leaves that user
+    /// chosen width untouched instead of unexpectedly shrinking the panel.
+    private var expandedFrameWidth: CGFloat?
+
     private let meetingStateManager: MeetingStateManager
     private let settingsStore: SettingsStore
     private let themeEngine: UIThemeEngine
@@ -34,6 +42,8 @@ final class MeetingWindowPanel: NSObject, NSWindowDelegate {
 
     /// Key under which AppKit autosaves this window's frame.
     private static let frameAutosaveName = "MeetingTranscriptionWindow"
+    private static let minimumHeight: CGFloat = 420
+    private static let widthTolerance: CGFloat = 0.5
 
     /// Whether AppKit has a stored frame for this window.
     ///
@@ -101,17 +111,20 @@ final class MeetingWindowPanel: NSObject, NSWindowDelegate {
     // MARK: - Private Helpers
 
     private func createPanel() {
-        let transcriptView = MeetingTranscriptView()
-            .environment(meetingStateManager)
-            .environment(settingsStore)
-            .environment(themeEngine)
-            .environment(historyStore)
+        let transcriptView = MeetingTranscriptView { [weak self] visible in
+            self?.setHistoryVisible(visible)
+        }
+        .environment(meetingStateManager)
+        .environment(settingsStore)
+        .environment(themeEngine)
+        .environment(historyStore)
 
         let hostingView = NSHostingView(rootView: transcriptView)
 
         let panel = NSPanel(
-            // Wide enough for the history sidebar plus a readable transcript.
-            contentRect: NSRect(x: 0, y: 0, width: 760, height: 560),
+            // Compact by default; opening history grows the panel by the sidebar
+            // width and closing it returns to this exact width.
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 560),
             styleMask: [.titled, .closable, .resizable, .nonactivatingPanel, .utilityWindow],
             backing: .buffered,
             defer: false
@@ -126,16 +139,56 @@ final class MeetingWindowPanel: NSObject, NSWindowDelegate {
         panel.hidesOnDeactivate = false
         panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
         panel.contentView = hostingView
-        // Matches the content's declared minimum. The transcript rows spend
-        // ~154pt on the timestamp and speaker columns before any text, so a
-        // narrower window leaves nothing readable beside the sidebar.
-        panel.minSize = NSSize(width: 620, height: 420)
+        panel.minSize = NSSize(
+            width: MeetingTranscriptView.compactMinimumWidth,
+            height: Self.minimumHeight
+        )
         panel.isReleasedWhenClosed = false
         panel.delegate = self
         // Persist position and size across close/reopen and across launches.
         panel.setFrameAutosaveName(Self.frameAutosaveName)
 
         self.panel = panel
+    }
+
+    /// Adjusts the AppKit window in lockstep with SwiftUI history visibility.
+    /// Opening remembers the exact compact frame width and expands by the fixed
+    /// sidebar + divider width. Closing restores it only when the user has not
+    /// resized the expanded window themselves.
+    private func setHistoryVisible(_ visible: Bool) {
+        guard let panel else { return }
+
+        if visible {
+            let compactWidth = panel.frame.width
+            compactFrameWidth = compactWidth
+            panel.minSize.width =
+                MeetingTranscriptView.compactMinimumWidth
+                + MeetingTranscriptView.historyWidthIncrement
+
+            var expandedFrame = panel.frame
+            expandedFrame.size.width = compactWidth + MeetingTranscriptView.historyWidthIncrement
+            panel.setFrame(expandedFrame, display: true, animate: true)
+            expandedFrameWidth = panel.frame.width
+            return
+        }
+
+        panel.minSize.width = MeetingTranscriptView.compactMinimumWidth
+        defer {
+            compactFrameWidth = nil
+            expandedFrameWidth = nil
+        }
+
+        guard
+            let compactFrameWidth,
+            let expandedFrameWidth,
+            abs(panel.frame.width - expandedFrameWidth) <= Self.widthTolerance
+        else {
+            return
+        }
+
+        var compactFrame = panel.frame
+        compactFrame.size.width = compactFrameWidth
+        panel.setFrame(compactFrame, display: true, animate: true)
     }
 
     // MARK: - NSWindowDelegate

--- a/wisprTests/MeetingAudioEngineTests.swift
+++ b/wisprTests/MeetingAudioEngineTests.swift
@@ -27,7 +27,7 @@ struct MeetingAudioEngineTests {
         let engine = MeetingAudioEngine()
 
         let stream = await engine.micAudioStream
-        var chunks: [[Float]] = []
+        var chunks: [MicAudioChunk] = []
         for await chunk in stream {
             chunks.append(chunk)
         }

--- a/wisprTests/MeetingStateManagerTests.swift
+++ b/wisprTests/MeetingStateManagerTests.swift
@@ -32,6 +32,21 @@ func createTestMeetingStateManager() -> MeetingStateManager {
     )
 }
 
+/// Same as `createTestMeetingStateManager()` but hands back the `SettingsStore`
+/// too, for tests that need to flip a setting the manager reads.
+@MainActor
+func createTestMeetingStateManagerWithSettings() -> (MeetingStateManager, SettingsStore) {
+    let settingsStore = SettingsStore(
+        defaults: UserDefaults(suiteName: "test.wispr.meeting.\(UUID().uuidString)")!
+    )
+    let manager = MeetingStateManager(
+        meetingAudioEngine: MeetingAudioEngine(),
+        transcriptionEngine: FakeMeetingTranscriptionEngine(),
+        settingsStore: settingsStore
+    )
+    return (manager, settingsStore)
+}
+
 // MARK: - MeetingTranscript Tests
 
 @Suite("MeetingTranscript Tests")
@@ -107,6 +122,127 @@ struct MeetingTranscriptTests {
         #expect(MeetingSpeaker.others(speakerIndex: 0).displayName == "Speaker 1")
         #expect(MeetingSpeaker.others(speakerIndex: 1).displayName == "Speaker 2")
         #expect(MeetingSpeaker.others(speakerIndex: 3).displayName == "Speaker 4")
+    }
+}
+
+// MARK: - In-Person Speaker Labelling
+
+/// Covers the behavioural heart of in-person mode (issue #97): the mic track is
+/// diarized and every participant — including the local user — becomes a numbered
+/// speaker, so nothing recorded in person is ever labelled "You".
+@Suite("Meeting In-Person Labelling Tests")
+struct MeetingInPersonLabellingTests {
+
+    @Test("In person, a resolved chunk is labelled with its diarized speaker")
+    func testInPersonResolvedIndex() {
+        let speaker = MeetingStateManager.micSpeaker(mode: .inPerson, diarizedIndex: 1)
+
+        #expect(speaker == .others(speakerIndex: 1))
+        #expect(speaker.displayName == "Speaker 2")
+    }
+
+    @Test("In person, an unresolved chunk falls back to Others rather than You")
+    func testInPersonColdStartFallsBackToOthers() {
+        // nil is the diarizer's cold-start window, or diarization being off.
+        let speaker = MeetingStateManager.micSpeaker(mode: .inPerson, diarizedIndex: nil)
+
+        #expect(speaker == .others(speakerIndex: nil))
+        #expect(speaker.displayName == "Others")
+    }
+
+    @Test("In person never labels microphone audio as You")
+    func testInPersonNeverYou() {
+        // There is no privileged local speaker in a room, so no diarizer outcome
+        // — resolved or not — may produce .you.
+        for index in [nil, 0, 1, 2, 3] as [Int?] {
+            let speaker = MeetingStateManager.micSpeaker(mode: .inPerson, diarizedIndex: index)
+            #expect(speaker != .you)
+            #expect(speaker.isRemote)
+        }
+    }
+
+    @Test("Online still labels microphone audio as You, ignoring any index")
+    func testOnlineIsAlwaysYou() {
+        #expect(MeetingStateManager.micSpeaker(mode: .online, diarizedIndex: nil) == .you)
+        // Online the mic is never diarized; a stray index must not leak a label.
+        #expect(MeetingStateManager.micSpeaker(mode: .online, diarizedIndex: 2) == .you)
+    }
+}
+
+// MARK: - Echo Suppression Mode Gate
+
+/// Covers the `record()` gate rather than `appendSuppressingEcho` itself: echo
+/// suppression exists to drop the mic's copy of *remote* speech, so in person —
+/// where there is no remote audio — it must be bypassed entirely. Two people in a
+/// room saying the same short phrase is real speech, not an echo.
+@Suite("Meeting Echo Suppression Mode Gate Tests")
+@MainActor
+struct MeetingEchoSuppressionModeGateTests {
+
+    /// Two near-identical entries close in time — exactly what suppression drops
+    /// online — recorded through the manager for a given session mode.
+    private func recordEchoPair(mode: MeetingMode) -> MeetingTranscript {
+        let (manager, settings) = createTestMeetingStateManagerWithSettings()
+        // The bypass only means anything while suppression is switched on.
+        settings.meetingEchoSuppressionEnabled = true
+        manager.transcript = MeetingTranscript()
+        manager.transcript.mode = mode
+
+        let base = Date()
+        manager.record(
+            MeetingTranscriptEntry(
+                speaker: .others(speakerIndex: 0),
+                text: "Let's review the quarterly numbers",
+                timestamp: base))
+        manager.record(
+            MeetingTranscriptEntry(
+                speaker: mode == .inPerson ? .others(speakerIndex: 1) : .you,
+                text: "Let's review the quarterly numbers.",
+                timestamp: base.addingTimeInterval(1)))
+
+        return manager.transcript
+    }
+
+    @Test("In person, a would-be echo is kept instead of suppressed")
+    func testInPersonKeepsWouldBeEcho() {
+        let transcript = recordEchoPair(mode: .inPerson)
+
+        // Both speakers survive: suppressing the second would silently delete a
+        // real participant's words.
+        #expect(transcript.entries.count == 2)
+        #expect(
+            transcript.entries.map(\.speaker) == [
+                .others(speakerIndex: 0), .others(speakerIndex: 1),
+            ])
+    }
+
+    @Test("Online, the same pair is still suppressed as microphone echo")
+    func testOnlineStillSuppressesEcho() {
+        let transcript = recordEchoPair(mode: .online)
+
+        // Control for the test above — proves the bypass is what changed the
+        // outcome, not the entries themselves.
+        #expect(transcript.entries.count == 1)
+        #expect(transcript.entries[0].speaker == .others(speakerIndex: 0))
+    }
+
+    @Test("In person ignores the echo-suppression setting entirely")
+    func testInPersonBypassIsIndependentOfSetting() {
+        let (manager, settings) = createTestMeetingStateManagerWithSettings()
+        settings.meetingEchoSuppressionEnabled = true
+        manager.transcript = MeetingTranscript()
+        manager.transcript.mode = .inPerson
+
+        let base = Date()
+        let text = "we should ship it this week"
+        for offset in [0.0, 1.0, 2.0] {
+            manager.record(
+                MeetingTranscriptEntry(
+                    speaker: .others(speakerIndex: 0), text: text,
+                    timestamp: base.addingTimeInterval(offset)))
+        }
+
+        #expect(manager.transcript.entries.count == 3)
     }
 }
 

--- a/wisprTests/TranscriptStoreTests.swift
+++ b/wisprTests/TranscriptStoreTests.swift
@@ -99,6 +99,60 @@ struct MeetingTranscriptCodableTests {
         #expect(restored.title == "Sprint review")
     }
 
+    @Test("Legacy JSON without mode decodes as an online meeting")
+    func testLegacyDecodeWithoutMode() throws {
+        // Same guard as speakerNames/title: transcripts archived before in-person
+        // mode existed carry no `mode` key, and must keep rendering with the
+        // original "You" / "Others" labelling rather than failing to decode.
+        let legacy = """
+            {
+              "entries": [
+                {
+                  "id": "3F2504E0-4F89-11D3-9A0C-0305E82C3301",
+                  "speaker": { "you": {} },
+                  "text": "bonjour",
+                  "timestamp": "2026-07-20T09:05:23Z"
+                }
+              ],
+              "startTime": "2026-07-20T09:05:00Z"
+            }
+            """
+
+        let transcript = try decoder.decode(MeetingTranscript.self, from: Data(legacy.utf8))
+
+        #expect(transcript.mode == .online)
+        // The archived "You" entry keeps its label, which is only correct because
+        // the mode defaulted to online.
+        #expect(transcript.displayName(for: .you) == "You")
+    }
+
+    @Test("An in-person mode survives an encode/decode round-trip")
+    func testModeRoundTrip() throws {
+        var transcript = MeetingTranscript(startTime: Date(timeIntervalSince1970: 1_000))
+        transcript.mode = .inPerson
+        transcript.entries.append(
+            MeetingTranscriptEntry(
+                speaker: .others(speakerIndex: 1), text: "salut",
+                timestamp: Date(timeIntervalSince1970: 1_010))
+        )
+
+        let restored = try decoder.decode(
+            MeetingTranscript.self, from: encoder.encode(transcript))
+
+        #expect(restored.mode == .inPerson)
+        #expect(restored.entries[0].speaker == .others(speakerIndex: 1))
+    }
+
+    @Test("An online mode survives an encode/decode round-trip")
+    func testOnlineModeRoundTrip() throws {
+        let transcript = MeetingTranscript(startTime: Date(timeIntervalSince1970: 1_000))
+
+        let restored = try decoder.decode(
+            MeetingTranscript.self, from: encoder.encode(transcript))
+
+        #expect(restored.mode == .online)
+    }
+
     @Test("Blank titles clear back to nil rather than storing whitespace")
     func testTitleTrimmingAndClearing() {
         var transcript = MeetingTranscript()


### PR DESCRIPTION
Add an Online/In person capture mode to the meeting window. In-person records the microphone only (no system audio, no Screen Recording permission) and diarizes the mic track so each person in the room becomes a numbered speaker, with no privileged "You".

- MeetingMode persisted on MeetingTranscript (decodeIfPresent, defaults to online so archived transcripts keep rendering)
- Timestamped MicAudioChunk so the diarizer has a mic timeline
- In-person forces diarization on and bypasses echo suppression (no remote audio to echo); labels reuse .others(speakerIndex:)
- Header mode toggle (locked while recording); in-person shows a single Room level; up to four participants (Sortformer limit)
- History sidebar now closed by default; opening it widens the panel and closing restores the prior compact width unless the user resized it
- Header controls never wrap: Start/Stop and the level indicator collapse to icon-only / hide when the window is too narrow

<img width="531" height="583" alt="image" src="https://github.com/user-attachments/assets/ab580049-402f-4c93-8523-503fe69cbfa8" />
<img width="416" height="583" alt="image" src="https://github.com/user-attachments/assets/b9c1c558-071d-4270-ae8c-afa8b8318a63" />
<img width="698" height="583" alt="image" src="https://github.com/user-attachments/assets/3698fe53-b220-4259-ae20-642c11db700e" />
