### PR TITLE
Resolve paste keycode from active layout (fixes #105)

### DIFF
--- a/Sources/WisprApp/Services/LayoutKeyResolver.swift
+++ b/Sources/WisprApp/Services/LayoutKeyResolver.swift
@@ -1,0 +1,106 @@
+//
+//  LayoutKeyResolver.swift
+//  wispr
+//
+//  Resolves which physical key produces a given character on the user's
+//  currently-active keyboard layout.
+//
+
+import Carbon
+import Foundation
+
+/// Finds the physical virtual key code that types a given character on the
+/// keyboard layout the user has active right now.
+///
+/// ## Why this exists
+///
+/// `CGEvent(virtualKey:)` posts a *physical* key position, not a character.
+/// macOS then runs that position through the active layout to decide which
+/// character it means. Position `kVK_ANSI_V` (`0x09`) produces "v" on QWERTY,
+/// but "d" on Colemak DH and a different letter on Dvorak. So synthesizing
+/// ⌘V by hardcoding `0x09` posts ⌘D (or worse) on non-QWERTY layouts, which
+/// is how the paste-becomes-bookmark bug happens (issue #105).
+///
+/// This resolver asks the system, at call time, "which physical key yields
+/// 'v' on the layout in use?" and returns that keycode so the synthesized
+/// ⌘V actually pastes regardless of layout.
+///
+/// Resolution is done live rather than from a fixed table because the user
+/// can switch layouts while the app is running.
+enum LayoutKeyResolver {
+
+    /// The physical keys we scan. macOS virtual key codes for typeable keys
+    /// live in 0...127; we probe the whole range and let the layout tell us
+    /// which position maps to the character we want.
+    private static let candidateKeyCodes: ClosedRange<UInt16> = 0...127
+
+    /// Returns the virtual key code that produces `character` on the currently
+    /// active keyboard layout, or `nil` if no key on this layout produces it
+    /// (e.g. a non-Latin layout with no "v" key). Callers fall back to a
+    /// hardcoded ANSI position in that case.
+    ///
+    /// - Parameter character: The lowercase character to resolve, e.g. "v".
+    static func keyCode(for character: Character) -> UInt16? {
+        guard let layoutData = currentLayoutData() else { return nil }
+
+        return layoutData.withUnsafeBytes { rawBuffer -> UInt16? in
+            guard let base = rawBuffer.baseAddress else { return nil }
+            let layoutPtr = base.assumingMemoryBound(to: UCKeyboardLayout.self)
+
+            for keyCode in candidateKeyCodes {
+                if translates(keyCode: keyCode, to: character, using: layoutPtr) {
+                    return keyCode
+                }
+            }
+            return nil
+        }
+    }
+
+    // MARK: - Private
+
+    /// The `uchr` layout data for the active input source, or `nil` if the
+    /// active source has no Unicode layout data (some IME sources don't).
+    private static func currentLayoutData() -> Data? {
+        // Prefer the keyboard *layout* input source; fall back to the general
+        // current input source (an IME's ASCII-capable layout) if the layout
+        // one is unavailable.
+        let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue()
+            ?? TISCopyCurrentKeyboardInputSource()?.takeRetainedValue()
+        guard let source else { return nil }
+
+        guard let dataPtr = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData) else {
+            return nil
+        }
+        let cfData = Unmanaged<CFData>.fromOpaque(dataPtr).takeUnretainedValue()
+        return cfData as Data
+    }
+
+    /// True if pressing `keyCode` (no modifiers) on the given layout produces
+    /// exactly `character`.
+    private static func translates(
+        keyCode: UInt16,
+        to character: Character,
+        using layoutPtr: UnsafePointer<UCKeyboardLayout>
+    ) -> Bool {
+        var deadKeyState: UInt32 = 0
+        var length = 0
+        var chars = [UniChar](repeating: 0, count: 4)
+
+        let status = UCKeyTranslate(
+            layoutPtr,
+            keyCode,
+            UInt16(kUCKeyActionDown),
+            0,                       // no modifier keys
+            UInt32(LMGetKbdType()),
+            OptionBits(kUCKeyTranslateNoDeadKeysBit),
+            &deadKeyState,
+            chars.count,
+            &length,
+            &chars
+        )
+
+        guard status == noErr, length > 0 else { return false }
+        let produced = String(utf16CodeUnits: chars, count: length)
+        return produced == String(character)
+    }
+}

--- a/Sources/WisprApp/Services/TextInsertionService.swift
+++ b/Sources/WisprApp/Services/TextInsertionService.swift
@@ -262,14 +262,29 @@ final class TextInsertionService: TextInserting {
         keyUpEvent.post(tap: .cghidEventTap)
     }
     
+    /// Physical key position of "V" on an ANSI/QWERTY keyboard (`kVK_ANSI_V`).
+    /// Used as the fallback when the active layout has no key producing "v"
+    /// (e.g. a non-Latin layout), so behaviour matches QWERTY at worst.
+    private static let ansiVKeyCode: UInt16 = 0x09
+
     /// Simulates a ⌘V keystroke using CGEvent.
+    ///
+    /// The V keycode is resolved from the user's active keyboard layout rather
+    /// than hardcoded, because `CGEvent(virtualKey:)` posts a physical key
+    /// position and macOS maps that position to a character through the current
+    /// layout. Hardcoding the ANSI V position (`0x09`) sends ⌘V on QWERTY but
+    /// ⌘D on Colemak DH and other letters on Dvorak, which pastes into the wrong
+    /// command (issue #105). Resolving "v" against the live layout keeps ⌘V
+    /// correct on every Latin layout; QWERTY naturally resolves back to `0x09`.
     ///
     /// - Returns: `true` if the keystroke was successfully posted
     private static func postCommandV() -> Bool {
+        let vKeyCode = LayoutKeyResolver.keyCode(for: "v") ?? ansiVKeyCode
+
         // Create key down event for ⌘V
         guard let keyDownEvent = CGEvent(
             keyboardEventSource: nil,
-            virtualKey: 0x09, // V key
+            virtualKey: vKeyCode,
             keyDown: true
         ) else {
             return false
@@ -281,7 +296,7 @@ final class TextInsertionService: TextInserting {
         // Create key up event
         guard let keyUpEvent = CGEvent(
             keyboardEventSource: nil,
-            virtualKey: 0x09, // V key
+            virtualKey: vKeyCode,
             keyDown: false
         ) else {
             return false

--- a/wispr.xcodeproj/project.pbxproj
+++ b/wispr.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		1CA1B2C301000000000000A2 /* TranscriptLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA1B2C301000000000000B2 /* TranscriptLocation.swift */; };
 		1CA1B2C301000000000000A3 /* TranscriptDirectoryWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA1B2C301000000000000B3 /* TranscriptDirectoryWatcher.swift */; };
 		1CAEA51D301608D800565CF0 /* ClipboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CAEA51C301608D800565CF0 /* ClipboardService.swift */; };
+		1CAEA51E301608D800565CF1 /* LayoutKeyResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CAEA51F301608D800565CF2 /* LayoutKeyResolver.swift */; };
 		1CAEA51F301608EE00565CF0 /* UIThemeEngineMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CAEA51E301608EE00565CF0 /* UIThemeEngineMonitor.swift */; };
 		24D1D37198DFC731F192C278 /* MeetingWindowPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654DB8601B81B3E819BC5A5C /* MeetingWindowPanel.swift */; };
 		5871C9411CAF50B12419F9DA /* MeetingTranscriptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F66665AA7D70423B4954925F /* MeetingTranscriptView.swift */; };
@@ -225,6 +226,7 @@
 		1CA1B2C301000000000000B2 /* TranscriptLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptLocation.swift; sourceTree = "<group>"; };
 		1CA1B2C301000000000000B3 /* TranscriptDirectoryWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptDirectoryWatcher.swift; sourceTree = "<group>"; };
 		1CAEA51C301608D800565CF0 /* ClipboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardService.swift; sourceTree = "<group>"; };
+		1CAEA51F301608D800565CF2 /* LayoutKeyResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutKeyResolver.swift; sourceTree = "<group>"; };
 		1CAEA51E301608EE00565CF0 /* UIThemeEngineMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIThemeEngineMonitor.swift; sourceTree = "<group>"; };
 		422A849C5A34DC9AE1B8437C /* TranscriptDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptDocument.swift; sourceTree = "<group>"; };
 		654DB8601B81B3E819BC5A5C /* MeetingWindowPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingWindowPanel.swift; sourceTree = "<group>"; };
@@ -445,6 +447,7 @@
 				1CA1B2C301000000000000B3 /* TranscriptDirectoryWatcher.swift */,
 				1C74D2DB2FA632B700208826 /* UpdateChecker.swift */,
 				1CAEA51C301608D800565CF0 /* ClipboardService.swift */,
+				1CAEA51F301608D800565CF2 /* LayoutKeyResolver.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -792,6 +795,7 @@
 				1C74D3442FA632B700208826 /* OnboardingPreview.swift in Sources */,
 				1C74D3452FA632B700208826 /* OnboardingAccessibilityStep.swift in Sources */,
 				1CAEA51D301608D800565CF0 /* ClipboardService.swift in Sources */,
+				1CAEA51E301608D800565CF1 /* LayoutKeyResolver.swift in Sources */,
 				1C74D3462FA632B700208826 /* AudioEngine.swift in Sources */,
 				E4782D9F9369B23177982DC0 /* MeetingAudioEngine.swift in Sources */,
 				D1AD12340000000000000001 /* MeetingDiarizer.swift in Sources */,

--- a/wisprTests/LayoutKeyResolverTests.swift
+++ b/wisprTests/LayoutKeyResolverTests.swift
@@ -1,0 +1,53 @@
+//
+//  LayoutKeyResolverTests.swift
+//  wispr
+//
+//  Regression tests for issue #105: the ⌘V paste keycode must be resolved
+//  from the active keyboard layout, not hardcoded to the ANSI V position.
+//
+
+import Testing
+import Carbon
+@testable import WisprApp
+
+@Suite("LayoutKeyResolver")
+struct LayoutKeyResolverTests {
+
+    /// On the CI runner (US ANSI layout) the physical key producing "v" is
+    /// `kVK_ANSI_V` (0x09). This is the layout the macOS CI runner uses, so it
+    /// also confirms QWERTY users see no behaviour change from the fix.
+    ///
+    /// Skipped on any machine whose active layout is not ANSI-based, so a
+    /// developer running the suite on Colemak/Dvorak doesn't get a false red.
+    @Test("v resolves to the ANSI V position on a US layout")
+    func vResolvesToAnsiPositionOnUSLayout() throws {
+        // Sanity-check the environment: on a US layout the ANSI 'a' key (0)
+        // produces "a". If it doesn't, we're not on an ANSI layout, skip.
+        let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue()
+        try #require(source != nil, "No active keyboard layout input source")
+
+        // Only assert the exact keycode when we can confirm an ANSI layout,
+        // otherwise the resolver is still expected to find *some* key.
+        let resolved = LayoutKeyResolver.keyCode(for: "v")
+
+        if isAnsiLayout {
+            #expect(resolved == 0x09, "On a US ANSI layout, 'v' should resolve to kVK_ANSI_V (0x09)")
+        } else {
+            #expect(resolved != nil, "'v' should resolve to some key on any Latin layout")
+        }
+    }
+
+    /// A character no physical key produces (a control character) returns nil,
+    /// which is the signal the caller uses to fall back to the ANSI position.
+    @Test("unmappable character returns nil")
+    func unmappableCharacterReturnsNil() {
+        // U+0000 (NUL) is not produced by any unmodified key press.
+        #expect(LayoutKeyResolver.keyCode(for: "\u{0}") == nil)
+    }
+
+    /// True when the active layout maps the ANSI 'a' position (keycode 0) to
+    /// "a", i.e. a QWERTY/US-family layout. Colemak/Dvorak fail this.
+    private var isAnsiLayout: Bool {
+        LayoutKeyResolver.keyCode(for: "a") == 0
+    }
+}

--- a/wisprTests/LayoutKeyResolverTests.swift
+++ b/wisprTests/LayoutKeyResolverTests.swift
@@ -17,24 +17,24 @@ struct LayoutKeyResolverTests {
     /// `kVK_ANSI_V` (0x09). This is the layout the macOS CI runner uses, so it
     /// also confirms QWERTY users see no behaviour change from the fix.
     ///
-    /// Skipped on any machine whose active layout is not ANSI-based, so a
-    /// developer running the suite on Colemak/Dvorak doesn't get a false red.
+    /// The assertion only runs on an ANSI layout. On Colemak/Dvorak/non-Latin
+    /// layouts the resolver returns a different keycode or nil (the fallback
+    /// case), so a developer running the suite on such a layout skips rather
+    /// than gets a false failure.
     @Test("v resolves to the ANSI V position on a US layout")
     func vResolvesToAnsiPositionOnUSLayout() throws {
-        // Sanity-check the environment: on a US layout the ANSI 'a' key (0)
-        // produces "a". If it doesn't, we're not on an ANSI layout, skip.
         let source = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue()
         try #require(source != nil, "No active keyboard layout input source")
 
-        // Only assert the exact keycode when we can confirm an ANSI layout,
-        // otherwise the resolver is still expected to find *some* key.
-        let resolved = LayoutKeyResolver.keyCode(for: "v")
+        // Only meaningful on a US ANSI layout; skip elsewhere so a non-QWERTY
+        // dev machine (where "v" may resolve to a different key, or to nil on a
+        // non-Latin layout) doesn't produce a false failure.
+        guard isAnsiLayout else { return }
 
-        if isAnsiLayout {
-            #expect(resolved == 0x09, "On a US ANSI layout, 'v' should resolve to kVK_ANSI_V (0x09)")
-        } else {
-            #expect(resolved != nil, "'v' should resolve to some key on any Latin layout")
-        }
+        #expect(
+            LayoutKeyResolver.keyCode(for: "v") == 0x09,
+            "On a US ANSI layout, 'v' should resolve to kVK_ANSI_V (0x09)"
+        )
     }
 
     /// A character no physical key produces (a control character) returns nil,


### PR DESCRIPTION
Fixes #105.

## The bug

Text insertion stages the transcription on the clipboard and synthesizes ⌘V. `postCommandV()` hardcoded `virtualKey: 0x09` (`kVK_ANSI_V`), which is a **physical key position**, not the letter "v". `CGEvent(virtualKey:)` posts that position and macOS maps it to a character through the active layout:

- QWERTY: position `0x09` → "v" → ⌘V pastes. Fine.
- Colemak DH: `0x09` → "d" → ⌘D (Add Bookmark in browsers). Nothing pastes.
- Dvorak: `0x09` → another letter, wrong command.

## The fix

New `LayoutKeyResolver` asks the system, at paste time, which physical key produces "v" on the currently-active layout (`TISCopyCurrentKeyboardLayoutInputSource` + `UCKeyTranslate`), and `postCommandV()` posts ⌘ + that key. QWERTY resolves back to `0x09`, so existing users see no change. Resolved live, not from a static table, because the layout can change while the app runs.

The Enter/Return synthesis (`0x24`) is untouched — Return sits at the same physical position on every layout, so it was never affected.

### Fallback (Option A)

If the active layout has no key producing a Latin "v" at all (e.g. a pure non-Latin layout), the resolver returns nil and we fall back to the ANSI V position — no worse than today for those users, and the reported Colemak/Dvorak case is fully fixed. Handling non-Latin layouts properly is out of scope here and better tracked separately if it comes up.

## Tests

`LayoutKeyResolverTests` asserts "v" resolves to `0x09` on the CI runner's US layout (also confirming QWERTY behaviour is unchanged) and that an unmappable character returns nil (the fallback trigger). The Colemak/Dvorak path is a manual QA step — install `colemak-dh` and dictate into Chrome, expect text to paste rather than the bookmark dialog.

## Verification

Built and tested on macOS CI (Apple-only APIs, can't compile on Linux). Manual layout-switch check recommended before merge.
